### PR TITLE
removed trailing whitespaces

### DIFF
--- a/Constructions/KeccakDuplex.c
+++ b/Constructions/KeccakDuplex.c
@@ -38,7 +38,7 @@ int Keccak_Duplexing(Keccak_DuplexInstance *instance, const unsigned char *sigma
 {
     unsigned char delimitedSigmaEnd1[1];
     const unsigned int rho_max = instance->rate - 2;
-    
+
     if (delimitedSigmaEnd == 0)
         return 1;
     if ((instance->byteInputIndex+sigmaBeginByteLen)*8 > rho_max)

--- a/Constructions/KeccakDuplex.h
+++ b/Constructions/KeccakDuplex.h
@@ -59,19 +59,19 @@ ALIGN typedef struct Keccak_DuplexInstanceStruct {
 int Keccak_DuplexInitialize(Keccak_DuplexInstance *duplexInstance, unsigned int rate, unsigned int capacity);
 
 /**
-  * Function to make a duplexing call to the duplex object initialized 
+  * Function to make a duplexing call to the duplex object initialized
   * with Keccak_DuplexInitialize().
-  * @param  duplexInstance  Pointer to the duplex instance initialized 
+  * @param  duplexInstance  Pointer to the duplex instance initialized
   *                     by Keccak_DuplexInitialize().
   * @param  sigmaBegin  Pointer to the first part of the input σ given as bytes.
   *                     Trailing bits are given in @a delimitedSigmaEnd.
   * @param  sigmaBeginByteLen   The number of input bytes provided in @a sigmaBegin.
   * @param  Z           Pointer to the buffer where to store the output data Z.
   * @param  ZByteLen    The number of output bytes desired for Z.
-  *                     If @a ZByteLen*8 is greater than the rate r, 
+  *                     If @a ZByteLen*8 is greater than the rate r,
   *                     the last byte contains only r modulo 8 bits,
   *                     in the least significant bits.
-  * @param  delimitedSigmaEnd   Byte containing from 0 to 7 trailing bits that must be 
+  * @param  delimitedSigmaEnd   Byte containing from 0 to 7 trailing bits that must be
   *                     appended to the input data in @a sigmaBegin.
   *                     These <i>n</i>=|σ| mod 8 bits must be in the least significant bit positions.
   *                     These bits must be delimited with a bit 1 at position <i>n</i>

--- a/Constructions/KeccakSponge.h
+++ b/Constructions/KeccakSponge.h
@@ -65,7 +65,7 @@ int Keccak_SpongeInitialize(Keccak_SpongeInstance *spongeInstance, unsigned int 
 /**
   * Function to give input data bytes for the sponge function to absorb.
   * @param  spongeInstance  Pointer to the sponge instance initialized by Keccak_SpongeInitialize().
-  * @param  data        Pointer to the input data. 
+  * @param  data        Pointer to the input data.
   * @param  dataByteLen  The number of input bytes provided in the input data.
   * @pre    The sponge function must be in the absorbing phase,
   *         i.e., Keccak_SpongeSqueeze() or Keccak_SpongeAbsorbLastFewBits()
@@ -78,7 +78,7 @@ int Keccak_SpongeAbsorb(Keccak_SpongeInstance *spongeInstance, const unsigned ch
   * Function to give input data bits for the sponge function to absorb
   * and then to switch to the squeezing phase.
   * @param  spongeInstance  Pointer to the sponge instance initialized by Keccak_SpongeInitialize().
-  * @param  delimitedData   Byte containing from 0 to 7 trailing bits 
+  * @param  delimitedData   Byte containing from 0 to 7 trailing bits
   *                     that must be absorbed.
   *                     These <i>n</i> bits must be in the least significant bit positions.
   *                     These bits must be delimited with a bit 1 at position <i>n</i>
@@ -100,8 +100,8 @@ int Keccak_SpongeAbsorbLastFewBits(Keccak_SpongeInstance *spongeInstance, unsign
 
 /**
   * Function to squeeze output data from the sponge function.
-  * If the sponge function was in the absorbing phase, this function 
-  * switches it to the squeezing phase 
+  * If the sponge function was in the absorbing phase, this function
+  * switches it to the squeezing phase
   * as if Keccak_SpongeAbsorbLastFewBits(spongeInstance, 0x01) was called.
   * @param  spongeInstance  Pointer to the sponge instance initialized by Keccak_SpongeInitialize().
   * @param  data        Pointer to the buffer where to store the output data.

--- a/Ketje/Ket/OptimizedAsmARM/Ket.h
+++ b/Ketje/Ket/OptimizedAsmARM/Ket.h
@@ -70,7 +70,7 @@ void Ket_StateOverwrite( void *state, unsigned int offset, const unsigned char *
   * @param  size                Size of data input in state.
   * @param  framing	            Framing value to pad after data.
   */
-void Ket_Step( void *state, unsigned int size, unsigned char framing ); 
+void Ket_Step( void *state, unsigned int size, unsigned char framing );
 
 /**
   * Function that feeds (partial) associated data that consists of a sequence of complete Ketje blocks.
@@ -83,7 +83,7 @@ void Ket_FeedAssociatedDataBlocks( void *state, const unsigned char *data, unsig
 
 /**
   * Function that presents a (partial) plaintext body that consists of a
-  * sequence of blocks for wrapping. 
+  * sequence of blocks for wrapping.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  plaintext           The (partial) plaintext body.
@@ -94,7 +94,7 @@ void Ket_UnwrapBlocks( void *state, const unsigned char *ciphertext, unsigned ch
 
 /**
   * Function that presents a (partial) ciphertext body that consists of a
-  * sequence of blocks for unwrapping. 
+  * sequence of blocks for unwrapping.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  ciphertext          The (partial) ciphertext body.

--- a/Ketje/Ket/OptimizedAsmARM/KetjeJr-armv7m-le-armcc.s
+++ b/Ketje/Ket/OptimizedAsmARM/KetjeJr-armv7m-le-armcc.s
@@ -419,7 +419,7 @@ KeccakP200_1_StatePermuteAsm   PROC
 	RhoPi	4, r9, _a, r8, _o		; _ga, _bo	 5 <  3
 	RhoPi	5, r8, _o, r11, _o		; _bo, _mo	 3 < 18
 	RhoPi	7, r11, _o, r11, _i		; _mo, _mi	18 < 17
-	RhoPi	2, r11, _i, r10, _e		; _mi, _ke	17 < 11	
+	RhoPi	2, r11, _i, r10, _e		; _mi, _ke	17 < 11
 	RhoPi	6, r10, _e, r9, _i		; _ke, _gi	11 <  7
 	RhoPi	3, r9, _i, r10, _a		; _gi, _ka	 7 < 10
 	RhoPi	1, r10, _a, r3,      0		; _ka, _be  10 < 1

--- a/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-armcc.s
+++ b/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-armcc.s
@@ -58,10 +58,10 @@ _AllocSize	equ 32*2
 		ldrh		r6, [$ptr, #$g]
 		eor			$result, $result, $rs
 		ldrh		$rs, [$ptr, #$k]
-		eor			$result, $result, r6				
+		eor			$result, $result, r6
 		ldrh		r6, [$ptr, #$m]
 		eor			$result, $result, $rs
-		eor			$result, $result, r6				
+		eor			$result, $result, r6
 		MEND
 
 		MACRO
@@ -71,10 +71,10 @@ _AllocSize	equ 32*2
 		ldr			r6, [$ptr, #$g]
 		eor			$resultL, $resultL, $rsL
 		ldr			$rsL, [$ptr, #$k]
-		eor			$resultL, $resultL, r6				
+		eor			$resultL, $resultL, r6
 		ldr			r6, [$ptr, #$m]
 		eor			$resultL, $resultL, $rsL
-		eor			$resultL, $resultL, r6				
+		eor			$resultL, $resultL, r6
 		lsr			$resultH, $resultL, #16
 		uxth 		$resultL, $resultL
 		MEND
@@ -259,11 +259,11 @@ Ket_Step   PROC
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 
@@ -282,7 +282,7 @@ Ket_Step   PROC
 Ket_FeedAssociatedDataBlocks   PROC
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
-	
+
 	lsrs	r3, r2, #1
 	bcc		Ket_FeedAssociatedDataBlocks_Even
 	adds	r2, r2, #1
@@ -298,21 +298,21 @@ Ket_FeedAssociatedDataBlocks   PROC
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 	b		Ket_FeedAssociatedDataBlocks_Odd
 
 Ket_FeedAssociatedDataBlocks_Even		; Even number of blocks
-    ldrh	r8, [r0, #_sa] 
-    ldrh	r9, [r0, #_se] 
-    ldrh	r10, [r0, #_si] 
-    ldrh	r12, [r0, #_su] 
-    ldrh	r11, [r0, #_so] 
+    ldrh	r8, [r0, #_sa]
+    ldrh	r9, [r0, #_se]
+    ldrh	r10, [r0, #_si]
+    ldrh	r12, [r0, #_su]
+    ldrh	r11, [r0, #_so]
 	mov		r5, r12
     xor5	r7, r0, _bu, _gu, _ku, _mu, r12
 
@@ -357,7 +357,7 @@ Ket_FeedAssociatedDataBlocks_Odd
 Ket_UnwrapBlocks   PROC
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
-	
+
 	lsrs	r4, r3, #1
 	bcc		Ket_UnwrapBlocks_Even
 	adds	r3, r3, #1
@@ -373,21 +373,21 @@ Ket_UnwrapBlocks   PROC
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 	b		Ket_UnwrapBlocks_Odd
 
 Ket_UnwrapBlocks_Even		; Even number of blocks
-    ldrh	r8, [r0, #_sa] 
-    ldrh	r9, [r0, #_se] 
-    ldrh	r10, [r0, #_si] 
-    ldrh	r12, [r0, #_su] 
-    ldrh	r11, [r0, #_so] 
+    ldrh	r8, [r0, #_sa]
+    ldrh	r9, [r0, #_se]
+    ldrh	r10, [r0, #_si]
+    ldrh	r12, [r0, #_su]
+    ldrh	r11, [r0, #_so]
 	mov		r5, r12
     xor5	r7, r0, _bu, _gu, _ku, _mu, r12
 
@@ -438,7 +438,7 @@ Ket_UnwrapBlocks_Odd
 Ket_WrapBlocks   PROC
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
-	
+
 	lsrs	r4, r3, #1
 	bcc		Ket_WrapBlocks_Even
 	adds	r3, r3, #1
@@ -454,21 +454,21 @@ Ket_WrapBlocks   PROC
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 	b		Ket_WrapBlocks_Odd
 
 Ket_WrapBlocks_Even		; Even number of blocks
-    ldrh	r8, [r0, #_sa] 
-    ldrh	r9, [r0, #_se] 
-    ldrh	r10, [r0, #_si] 
-    ldrh	r12, [r0, #_su] 
-    ldrh	r11, [r0, #_so] 
+    ldrh	r8, [r0, #_sa]
+    ldrh	r9, [r0, #_se]
+    ldrh	r10, [r0, #_si]
+    ldrh	r12, [r0, #_su]
+    ldrh	r11, [r0, #_so]
 	mov		r5, r12
     xor5	r7, r0, _bu, _gu, _ku, _mu, r12
 

--- a/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-gcc.s
+++ b/Ketje/Ket/OptimizedAsmARM/KetjeSr-armv7m-le-gcc.s
@@ -57,10 +57,10 @@
 		ldrh		r6, [\ptr, #\g]
 		eor			\result, \result, \rs
 		ldrh		\rs, [\ptr, #\k]
-		eor			\result, \result, r6				
+		eor			\result, \result, r6
 		ldrh		r6, [\ptr, #\m]
 		eor			\result, \result, \rs
-		eor			\result, \result, r6				
+		eor			\result, \result, r6
 		.endm
 
 .macro		xor5D		resultL,resultH,ptr,b,g,k,m,rsL,rsH
@@ -69,10 +69,10 @@
 		ldr			r6, [\ptr, #\g]
 		eor			\resultL, \resultL, \rsL
 		ldr			\rsL, [\ptr, #\k]
-		eor			\resultL, \resultL, r6				
+		eor			\resultL, \resultL, r6
 		ldr			r6, [\ptr, #\m]
 		eor			\resultL, \resultL, \rsL
-		eor			\resultL, \resultL, r6				
+		eor			\resultL, \resultL, r6
 		lsr			\resultH, \resultL, #16
 		uxth 		\resultL, \resultL
 		.endm
@@ -212,7 +212,7 @@
 @//
 .align 8
 .global   Ket_StateOverwrite
-Ket_StateOverwrite:  
+Ket_StateOverwrite:
 	cmp		r3, #0
 	beq		Ket_StateOverwrite_Exit
 	adds	r0, r0, r1
@@ -231,7 +231,7 @@ Ket_StateOverwrite_Exit:
 @//
 .align 8
 .global   Ket_Step
-Ket_Step:  
+Ket_Step:
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
 
@@ -252,11 +252,11 @@ Ket_Step:
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 
@@ -272,10 +272,10 @@ Ket_Step:
 @//
 .align 8
 .global   Ket_FeedAssociatedDataBlocks
-Ket_FeedAssociatedDataBlocks:  
+Ket_FeedAssociatedDataBlocks:
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
-	
+
 	lsrs	r3, r2, #1
 	bcc		Ket_FeedAssociatedDataBlocks_Even
 	adds	r2, r2, #1
@@ -291,21 +291,21 @@ Ket_FeedAssociatedDataBlocks:
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 	b		Ket_FeedAssociatedDataBlocks_Odd
 
 Ket_FeedAssociatedDataBlocks_Even:		@ Even number of blocks
-    ldrh	r8, [r0, #_sa] 
-    ldrh	r9, [r0, #_se] 
-    ldrh	r10, [r0, #_si] 
-    ldrh	r12, [r0, #_su] 
-    ldrh	r11, [r0, #_so] 
+    ldrh	r8, [r0, #_sa]
+    ldrh	r9, [r0, #_se]
+    ldrh	r10, [r0, #_si]
+    ldrh	r12, [r0, #_su]
+    ldrh	r11, [r0, #_so]
 	mov		r5, r12
     xor5	r7, r0, _bu, _gu, _ku, _mu, r12
 
@@ -347,10 +347,10 @@ Ket_FeedAssociatedDataBlocks_Odd:
 @//
 .align 8
 .global   Ket_UnwrapBlocks
-Ket_UnwrapBlocks:  
+Ket_UnwrapBlocks:
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
-	
+
 	lsrs	r4, r3, #1
 	bcc		Ket_UnwrapBlocks_Even
 	adds	r3, r3, #1
@@ -366,21 +366,21 @@ Ket_UnwrapBlocks:
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 	b		Ket_UnwrapBlocks_Odd
 
 Ket_UnwrapBlocks_Even:		@ Even number of blocks
-    ldrh	r8, [r0, #_sa] 
-    ldrh	r9, [r0, #_se] 
-    ldrh	r10, [r0, #_si] 
-    ldrh	r12, [r0, #_su] 
-    ldrh	r11, [r0, #_so] 
+    ldrh	r8, [r0, #_sa]
+    ldrh	r9, [r0, #_se]
+    ldrh	r10, [r0, #_si]
+    ldrh	r12, [r0, #_su]
+    ldrh	r11, [r0, #_so]
 	mov		r5, r12
     xor5	r7, r0, _bu, _gu, _ku, _mu, r12
 
@@ -428,10 +428,10 @@ Ket_UnwrapBlocks_Odd:
 @//
 .align 8
 .global   Ket_WrapBlocks
-Ket_WrapBlocks:  
+Ket_WrapBlocks:
 	push	{r4-r12,lr}
 	sub		sp, sp, #_AllocSize
-	
+
 	lsrs	r4, r3, #1
 	bcc		Ket_WrapBlocks_Even
 	adds	r3, r3, #1
@@ -447,21 +447,21 @@ Ket_WrapBlocks:
 	ldrh	r12, [r0, #_su]
 	strh	r12, [sp, #_su]
 
-    ldrh	r8, [sp, #_sa] 
-    ldrh	r9, [sp, #_se] 
-    ldrh	r10, [sp, #_si] 
-    ldrh	r12, [sp, #_su] 
-    ldrh	r11, [sp, #_so] 
+    ldrh	r8, [sp, #_sa]
+    ldrh	r9, [sp, #_se]
+    ldrh	r10, [sp, #_si]
+    ldrh	r12, [sp, #_su]
+    ldrh	r11, [sp, #_so]
 	mov		r5, r12
     xor5	r7, sp, _bu, _gu, _ku, _mu, r12
 	b		Ket_WrapBlocks_Odd
 
 Ket_WrapBlocks_Even:		@ Even number of blocks
-    ldrh	r8, [r0, #_sa] 
-    ldrh	r9, [r0, #_se] 
-    ldrh	r10, [r0, #_si] 
-    ldrh	r12, [r0, #_su] 
-    ldrh	r11, [r0, #_so] 
+    ldrh	r8, [r0, #_sa]
+    ldrh	r9, [r0, #_se]
+    ldrh	r10, [r0, #_si]
+    ldrh	r12, [r0, #_su]
+    ldrh	r11, [r0, #_so]
 	mov		r5, r12
     xor5	r7, r0, _bu, _gu, _ku, _mu, r12
 
@@ -507,7 +507,7 @@ Ket_WrapBlocks_Odd:
 @//
 @// Keccak-P[400, 1] usable from asm only, from r0 to sp
 @//
-KeccakP400_1_StatePermuteToStack:  
+KeccakP400_1_StatePermuteToStack:
 	KeccakRound	sp, r0
 	bx			lr
 
@@ -516,7 +516,7 @@ KeccakP400_1_StatePermuteToStack:
 @//
 @// Keccak-P[400, 1] usable from asm only, from sp to r0
 @//
-KeccakP400_1_StatePermuteFromStack:  
+KeccakP400_1_StatePermuteFromStack:
 	KeccakRound	r0, sp
 	bx			lr
 

--- a/Ketje/Ket/OptimizedLE/Ket.c
+++ b/Ketje/Ket/OptimizedLE/Ket.c
@@ -22,7 +22,7 @@ void Ket_StateOverwrite( void *stateArg, unsigned int offset, const unsigned cha
 {
 	unsigned char *state = (unsigned char*)stateArg + offset;
 
-	while ( length-- != 0 ) 
+	while ( length-- != 0 )
 	{
 		*(state++) = *(data++);
 	}

--- a/Ketje/Ket/OptimizedLE/Ket.h
+++ b/Ketje/Ket/OptimizedLE/Ket.h
@@ -70,7 +70,7 @@ void Ket_StateOverwrite( void *state, unsigned int offset, const unsigned char *
   * @param  size                Size of data input in state.
   * @param  framing	            Framing value to pad after data.
   */
-void Ket_Step( void *state, unsigned int size, unsigned char framing ); 
+void Ket_Step( void *state, unsigned int size, unsigned char framing );
 
 /**
   * Function that feeds (partial) associated data that consists of a sequence of complete Ketje blocks.
@@ -83,7 +83,7 @@ void Ket_FeedAssociatedDataBlocks( void *state, const unsigned char *data, unsig
 
 /**
   * Function that presents a (partial) plaintext body that consists of a
-  * sequence of blocks for wrapping. 
+  * sequence of blocks for wrapping.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  plaintext           The (partial) plaintext body.
@@ -94,7 +94,7 @@ void Ket_UnwrapBlocks( void *state, const unsigned char *ciphertext, unsigned ch
 
 /**
   * Function that presents a (partial) ciphertext body that consists of a
-  * sequence of blocks for unwrapping. 
+  * sequence of blocks for unwrapping.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  ciphertext          The (partial) ciphertext body.

--- a/Ketje/Ket/Reference/Ket.c
+++ b/Ketje/Ket/Reference/Ket.c
@@ -62,7 +62,7 @@ void Ket_FeedAssociatedDataBlocks( void *state, const unsigned char *data, unsig
 		Ket_StateXORByte( state, 2, *(data++) );
 		Ket_StateXORByte( state, 3, *(data++) );
 		#endif
-		Ket_Step( state, Ketje_BlockSize, FRAMEBITS00 ); 
+		Ket_Step( state, Ketje_BlockSize, FRAMEBITS00 );
 	}
 	while ( --nBlocks != 0 );
 }
@@ -72,8 +72,8 @@ void Ket_UnwrapBlocks( void *state, const unsigned char *ciphertext, unsigned ch
 	unsigned char tempBlock[Ketje_BlockSize];
     unsigned char frameAndPaddingBits[1];
     frameAndPaddingBits[0] = 0x08 | FRAMEBITS11;
-	
-	while ( nBlocks-- != 0 ) 
+
+	while ( nBlocks-- != 0 )
 	{
 		SnP_ExtractBytes(state, tempBlock, 0, Ketje_BlockSize);
 		tempBlock[0] = *(plaintext++) = *(ciphertext++) ^ tempBlock[0];
@@ -95,7 +95,7 @@ void Ket_WrapBlocks( void *state, const unsigned char *plaintext, unsigned char 
     unsigned char frameAndPaddingBits[1];
     frameAndPaddingBits[0] = 0x08 | FRAMEBITS11;
 
-	while ( nBlocks-- != 0 ) 
+	while ( nBlocks-- != 0 )
 	{
 		SnP_ExtractBytes(state, keystream, 0, Ketje_BlockSize);
 		plaintemp[0] = plaintext[0];

--- a/Ketje/Ket/Reference/Ket.h
+++ b/Ketje/Ket/Reference/Ket.h
@@ -62,13 +62,13 @@ void Ket_StateOverwrite( void *state, unsigned int offset, const unsigned char *
 void Ket_StateXORByte( void *state, unsigned int offset, unsigned char data );
 
 /**
-  * Function that performs a step, after XORing a framing byte into the state at requested offset. 
+  * Function that performs a step, after XORing a framing byte into the state at requested offset.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  size                Offset in bytes where to XOR the framing value in the state.
   * @param  frameAndPaddingBits Framing value to pad after data.
   */
-void Ket_Step( void *state, unsigned int size, unsigned char frameAndPaddingBits ); 
+void Ket_Step( void *state, unsigned int size, unsigned char frameAndPaddingBits );
 
 /**
   * Function that feeds (partial) associated data that consists of a sequence of complete Ketje blocks.
@@ -81,7 +81,7 @@ void Ket_FeedAssociatedDataBlocks( void *state, const unsigned char *data, unsig
 
 /**
   * Function that presents a (partial) plaintext body that consists of a
-  * sequence of blocks for wrapping. 
+  * sequence of blocks for wrapping.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  plaintext           The (partial) plaintext body.
@@ -92,7 +92,7 @@ void Ket_UnwrapBlocks( void *state, const unsigned char *ciphertext, unsigned ch
 
 /**
   * Function that presents a (partial) ciphertext body that consists of a
-  * sequence of blocks for unwrapping. 
+  * sequence of blocks for unwrapping.
   *
   * @param  state    		    Pointer to the permutation state.
   * @param  ciphertext          The (partial) ciphertext body.

--- a/Ketje/Ketje.h
+++ b/Ketje/Ketje.h
@@ -31,7 +31,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #endif
 
 /** The phase is a data element that expresses what Ketje is doing
- * - virgin: the only operation supported is initialization, loading the key and nonce. This will switch 
+ * - virgin: the only operation supported is initialization, loading the key and nonce. This will switch
  *   the phase to feedingAssociatedData
  * - feedingAssociatedData: Ketje is ready for feeding associated data, has started feeding associated data
  *   or has finished feeding associated data. It allows feeding some more associated data in which case the phase does not
@@ -60,7 +60,7 @@ ALIGN typedef struct {
     /** The phase. */
     unsigned int phase;
 
-	/** The amount of associated or plaintext data that has been 
+	/** The amount of associated or plaintext data that has been
       * XORed into the state after the last call to step or stride */
     unsigned int dataRemainderSize;
 } Ketje_Instance;

--- a/Modes/KeccakHash.h
+++ b/Modes/KeccakHash.h
@@ -34,11 +34,11 @@ typedef struct {
   * @param  hashInstance    Pointer to the hash instance to be initialized.
   * @param  rate        The value of the rate r.
   * @param  capacity    The value of the capacity c.
-  * @param  hashbitlen  The desired number of output bits, 
+  * @param  hashbitlen  The desired number of output bits,
   *                     or 0 for an arbitrarily-long output.
   * @param  delimitedSuffix Bits that will be automatically appended to the end
   *                         of the input message, as in domain separation.
-  *                         This is a byte containing from 0 to 7 bits 
+  *                         This is a byte containing from 0 to 7 bits
   *                         formatted like the @a delimitedData parameter of
   *                         the Keccak_SpongeAbsorbLastFewBits() function.
   * @pre    One must have r+c=1600 and the rate a multiple of 8 bits in this implementation.
@@ -73,7 +73,7 @@ HashReturn Keccak_HashInitialize(Keccak_HashInstance *hashInstance, unsigned int
 /**
   * Function to give input data to be absorbed.
   * @param  hashInstance    Pointer to the hash instance initialized by Keccak_HashInitialize().
-  * @param  data        Pointer to the input data. 
+  * @param  data        Pointer to the input data.
   *                     When @a databitLen is not a multiple of 8, the last bits of data must be
   *                     in the least significant bits of the last byte (little-endian convention).
   * @param  databitLen  The number of input bits provided in the input data.
@@ -86,7 +86,7 @@ HashReturn Keccak_HashUpdate(Keccak_HashInstance *hashInstance, const BitSequenc
   * Function to call after all input blocks have been input and to get
   * output bits if the length was specified when calling Keccak_HashInitialize().
   * @param  hashInstance    Pointer to the hash instance initialized by Keccak_HashInitialize().
-  * If @a hashbitlen was not 0 in the call to Keccak_HashInitialize(), the number of 
+  * If @a hashbitlen was not 0 in the call to Keccak_HashInitialize(), the number of
   *     output bits is equal to @a hashbitlen.
   * If @a hashbitlen was 0 in the call to Keccak_HashInitialize(), the output bits
   *     must be extracted using the Keccak_HashSqueeze() function.

--- a/PlSnP/2/KeccakF-1600/OptimizedAsmARM/KeccakF-1600-inplace-pl2-armv7a-neon-gcc.s
+++ b/PlSnP/2/KeccakF-1600/OptimizedAsmARM/KeccakF-1600-inplace-pl2-armv7a-neon-gcc.s
@@ -13,14 +13,14 @@
 @ http://creativecommons.org/publicdomain/zero/1.0/
 @
 
-@ WARNING: These functions work only on little endian CPU with@ ARMv7A + NEON architecture 
+@ WARNING: These functions work only on little endian CPU with@ ARMv7A + NEON architecture
 @ WARNING: State must be 256 bit (32 bytes) aligned, best is 64-byte (cache alignment).
 
 @ INFO: Tested on Cortex-A8 (BeagleBone Black), using gcc.
 @ INFO: Parallel execution of Keccak-F permutation on 2 lane interleaved states.
 
 
-    
+
 .text
 
 @----------------------------------------------------------------------------
@@ -105,7 +105,7 @@
     @ argA2 =   Be ^((~Bi)& Bo )
     @ argA3 =   Bi ^((~Bo)& Bu )
     @ argA4 =   Bo ^((~Bu)& Ba )
-    @ argA5 =   Bu ^((~Ba)& Be ) 
+    @ argA5 =   Bu ^((~Ba)& Be )
     @ argA1 =   Ba ^((~Be)& Bi )
     @ argA1 ^= KeccakF1600RoundConstants[i+round]
     vsri.64     d1,    \argA2,   #64-44
@@ -129,7 +129,7 @@
     vbic.64     \argA4, d0,      d4
     veor.64     \argA2, d1
     vstr.64     d5,    [r0, #\argA1]
-    veor.64     \argA3, d2    
+    veor.64     \argA3, d2
     veor.64     \argA4, d3
     veor.64     \argA5, d4
     .endm
@@ -319,7 +319,7 @@
     vld1.64		{ \qreg }, [r3:128], r4
     .endif
     .endm
-    
+
 .macro    m_st		qreg, next
     .if \next == 16
     vst1.64		{ \qreg }, [r3:128]!
@@ -355,7 +355,7 @@
     .endif
     veor.64		q9,	q9,  q3
     veor.64		q5,	q5,  q4
-    
+
     @ Ba = argA1^Da
     @ Be = ROL64(argA2^De, 44)
     @ Bi = ROL64(argA3^Di, 43)
@@ -394,7 +394,7 @@
     @ argA2 = Be ^(~Bi & Bo)
     @ argA3 = Bi ^(~Bo & Bu)
     @ argA4 = Bo ^(~Bu & Ba)
-    @ argA5 = Bu ^(~Ba & Be) 
+    @ argA5 = Bu ^(~Ba & Be)
     vld1.64		{ d30 },	[r1:64]
     vbic.64		q0,	q12,	q11
     vbic.64		q1,	q13,	q12
@@ -409,7 +409,7 @@
     veor.64	q1,	q11
     m_st	q0, \next
     m_pls	\ofs2
-    veor.64	q2,	q12    
+    veor.64	q2,	q12
     m_st	q1, \next
     m_pls	\ofs3
     veor.64	q3,	q13
@@ -486,7 +486,7 @@
     veor.64	q1,   q1,  q6
     vld1.64	{ q6 }, [r6:128]!
     veor.64	q8,   q8,   q13
-    
+
     m_st	q7, \next
     m_pls	\ofs4
     veor.64	q2,   q2,  q7
@@ -592,9 +592,9 @@
 @
    .align 8
 .global   KeccakF1600_Pl_Initialize
-KeccakF1600_Pl_Initialize:  
+KeccakF1600_Pl_Initialize:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -602,7 +602,7 @@ KeccakF1600_Pl_Initialize:
 @
    .align 8
 .global   KeccakF1600_Pl2_InitializeAll
-KeccakF1600_Pl2_InitializeAll:  
+KeccakF1600_Pl2_InitializeAll:
     vmov.i64	q0, #0
     vmov.i64	q1, #0
     vmov.i64	q2, #0
@@ -615,7 +615,7 @@ KeccakF1600_Pl2_InitializeAll:
     vstm		r0!, { d0 - d7 }      @ 48
     vstm		r0!, { d0 - d1}	      @ 50
     bx			lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -623,7 +623,7 @@ KeccakF1600_Pl2_InitializeAll:
 @
    .align 8
 .global 	KeccakF1600_Pl2_ComplementBit
-KeccakF1600_Pl2_ComplementBit:  
+KeccakF1600_Pl2_ComplementBit:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     lsr		r1, r2, #6					@ states += position / 64 * 2 * 8
     add		r0, r0, r1, LSL #4
@@ -636,7 +636,7 @@ KeccakF1600_Pl2_ComplementBit:
     eor		r2, r2, r3
     str		r2, [r0, r1, LSL #2]
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -644,14 +644,14 @@ KeccakF1600_Pl2_ComplementBit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_ComplementBitAll
-KeccakF1600_Pl2_ComplementBitAll:  
+KeccakF1600_Pl2_ComplementBitAll:
     lsr		r2, r1, #6					@ states += position / 64 * 2 * 8
     add		r0, r0, r2, LSL #4
     lsr 	r2, r1, #5					@ r2 = (position / 32) & 1
     and		r2, r2, #1
     mov 	r3, #1						@ r3 = (1 << (position % 32))
     and		r1, r1, #31
-    add		r0, r0, r2, LSL #2			@ states += 4 * r2 
+    add		r0, r0, r2, LSL #2			@ states += 4 * r2
     lsl		r3, r3, r1
     ldr		r1, [r0]
     ldr		r2, [r0, #8]
@@ -660,16 +660,16 @@ KeccakF1600_Pl2_ComplementBitAll:
     str		r1, [r0]
     str		r2, [r0, #8]
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_XORBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_XORBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global   KeccakF1600_Pl2_XORBytes
-KeccakF1600_Pl2_XORBytes:  
+KeccakF1600_Pl2_XORBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -719,7 +719,7 @@ KeccakF1600_Pl2_XORBytes_Done:
     pop		{ r4- r7 }
 KeccakF1600_Pl2_XORBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -727,7 +727,7 @@ KeccakF1600_Pl2_XORBytes_Exit:
 @
 .global   KeccakF1600_Pl2_XORLanesAll
    .align 8
-KeccakF1600_Pl2_XORLanesAll:  
+KeccakF1600_Pl2_XORLanesAll:
     cmp		r2, #0
     beq		KeccakF1600_Pl2_XORLanesAll_Exit
     add		r3, r1, r3, LSL #3		@ r3: data + 8 * laneOffset
@@ -750,16 +750,16 @@ KeccakF1600_Pl2_XORLanesAll_Loop:
     pop		{r4 - r7}
 KeccakF1600_Pl2_XORLanesAll_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_OverwriteBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_OverwriteBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global 	KeccakF1600_Pl2_OverwriteBytes
-KeccakF1600_Pl2_OverwriteBytes: 
+KeccakF1600_Pl2_OverwriteBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -801,7 +801,7 @@ KeccakF1600_Pl2_OverwriteBytes_Done:
     pop		{ r4- r5 }
 KeccakF1600_Pl2_OverwriteBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -809,7 +809,7 @@ KeccakF1600_Pl2_OverwriteBytes_Exit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_OverwriteLanesAll
-KeccakF1600_Pl2_OverwriteLanesAll: 
+KeccakF1600_Pl2_OverwriteLanesAll:
     cmp		r2, #0
     beq		KeccakF1600_Pl2_OverwriteLanesAll_Exit
     lsls	r12, r1, #32-3
@@ -845,7 +845,7 @@ KeccakF1600_Pl2_OverwriteLanesAll_LoopUnaligned:
     pop		{ r4, r5 }
 KeccakF1600_Pl2_OverwriteLanesAll_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -853,14 +853,14 @@ KeccakF1600_Pl2_OverwriteLanesAll_Exit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_OverwriteWithZeroes
-KeccakF1600_Pl2_OverwriteWithZeroes: 
+KeccakF1600_Pl2_OverwriteWithZeroes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     lsrs	r1, r2, #3					@ r1: laneCount
     beq		KeccakF1600_Pl2_OverwriteWithZeroes_Bytes
     vmov.i64 d0, #0
 KeccakF1600_Pl2_OverwriteWithZeroes_LoopLanes:
     subs	r1, r1, #1
-    vstm    r0!, { d0 }    
+    vstm    r0!, { d0 }
     add		r0, r0, #8
     bne		KeccakF1600_Pl2_OverwriteWithZeroes_LoopLanes
 KeccakF1600_Pl2_OverwriteWithZeroes_Bytes:
@@ -873,16 +873,16 @@ KeccakF1600_Pl2_OverwriteWithZeroes_LoopBytes:
     bne		KeccakF1600_Pl2_OverwriteWithZeroes_LoopBytes
 KeccakF1600_Pl2_OverwriteWithZeroes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_ExtractBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_ExtractBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global 	KeccakF1600_Pl2_ExtractBytes
-KeccakF1600_Pl2_ExtractBytes:  
+KeccakF1600_Pl2_ExtractBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -924,7 +924,7 @@ KeccakF1600_Pl2_ExtractBytes_Done:
     pop		{ r4-r5 }
 KeccakF1600_Pl2_ExtractBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -932,7 +932,7 @@ KeccakF1600_Pl2_ExtractBytes_Exit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_ExtractLanesAll
-KeccakF1600_Pl2_ExtractLanesAll:  
+KeccakF1600_Pl2_ExtractLanesAll:
     cmp		r2, #0
     beq		KeccakF1600_Pl2_ExtractLanesAll_Exit
     lsls	r12, r1, #32-3
@@ -968,16 +968,16 @@ KeccakF1600_Pl2_ExtractLanesAll_LoopUnaligned:
     pop		{ r4, r5 }
 KeccakF1600_Pl2_ExtractLanesAll_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_ExtractAndXORBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_ExtractAndXORBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global 	KeccakF1600_Pl2_ExtractAndXORBytes
-KeccakF1600_Pl2_ExtractAndXORBytes:  
+KeccakF1600_Pl2_ExtractAndXORBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -1027,7 +1027,7 @@ KeccakF1600_Pl2_ExtractAndXORBytes_Done:
     pop		{ r4- r7 }
 KeccakF1600_Pl2_ExtractAndXORBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -1091,7 +1091,7 @@ KeccakF1600_Pl2_ExtractAndXORLanesAll_LoopUnaligned:
     pop		{ r4 - r7 }
 KeccakF1600_Pl2_ExtractAndXORLanesAll_Exit:
     bx		lr
-   
+
 
    .align 8
 KeccakF1600_Pl2_Permute_RoundConstants:
@@ -1126,7 +1126,7 @@ KeccakF1600_Pl2_Permute_RoundConstants:
 @
    .align 8
 .global 	KeccakF1600_Pl2_Permute
-KeccakF1600_Pl2_Permute:  
+KeccakF1600_Pl2_Permute:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     adr		r1, KeccakF1600_Pl2_Permute_RoundConstants
     movs	r2, #24
@@ -1204,7 +1204,7 @@ KeccakF1600_ParallelPermute_RoundLoop:
     vstr.64 d31, [r0, #_su]
     vpop    {q4-q7}
     bx      lr
-   
+
 
    .align 8
 KeccakF1600_Pl2_PermuteAll_RoundConstants:
@@ -1239,7 +1239,7 @@ KeccakF1600_Pl2_PermuteAll_RoundConstants:
 @
    .align 8
 .global 	KeccakF1600_Pl2_PermuteAll
-KeccakF1600_Pl2_PermuteAll:  
+KeccakF1600_Pl2_PermuteAll:
     adr		r1, KeccakF1600_Pl2_PermuteAll_RoundConstants
     movs	r2, #24
     vpush	{q4-q7}
@@ -1258,76 +1258,76 @@ KeccakF1600_Pl2_PermuteAll:
     bic		r5, #15
     vld1.64	{ d4, d5, d6, d7 }, [r3:256]!	@ _bi _bo
     vld1.64	{ d8, d9, d10, d11 }, [r3:256]!	@ _bu _ga
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _ge 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _ge
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _gi
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _go
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _gu 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _gu
     veor.64	q3, q3, q8
     vld1.64	{ d10, d11 }, [r3:128]!	@ _ka
     veor.64	q4, q4, q9
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _ke 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _ke
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _ki
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _ko
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _ku 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _ku
     veor.64	q3, q3, q8
     vld1.64	{ d10, d11 }, [r3:128]!	@ _ma
     veor.64	q4, q4, q9
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _me 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _me
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _mi
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _mo
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _mu 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _mu
     veor.64	q3, q3, q8
     vld1.64	{ d10, d11 }, [r3:128]!	@ _sa
     veor.64	q4, q4, q9
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _se 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _se
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _si
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _so
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _su 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _su
     mov		r3, r0
     veor.64	q3, q3, q8
     veor.64	q4, q4, q9
-    
+
 KeccakF1600_Pl2_PermuteAll_RoundLoop:
     KeccakP_ThetaRhoPiChiIota  _ba,  -1,  -1,  -1,  -1, _ge-_ba, _ka @ _ba, _ge, _ki, _mo, _su
     KeccakP_ThetaRhoPiChi1     _ka,  -1,  -1,  _bo, -1, _me-_ka, _sa @ _ka, _me, _si, _bo, _gu
     KeccakP_ThetaRhoPiChi2     _sa, _be,  -1,  -1,  -1, _gi-_be, _ga @ _sa, _be, _gi, _ko, _mu
     KeccakP_ThetaRhoPiChi3     _ga,  -1,  -1,  -1, _bu, _ke-_ga, _ma @ _ga, _ke, _mi, _so, _bu
     KeccakP_ThetaRhoPiChi4     _ma,  -1, _bi,  -1,  -1, _se-_ma, _ba @ _ma, _se, _bi, _go, _ku
-                                                                       
+
     KeccakP_ThetaRhoPiChiIota  _ba,  -1, _gi,  -1, _ku, _me-_ba, _sa @ _ba, _me, _gi, _so, _ku
     KeccakP_ThetaRhoPiChi1     _sa, _ke, _bi,  -1, _gu, _mo-_bi, _ma @ _sa, _ke, _bi, _mo, _gu
     KeccakP_ThetaRhoPiChi2     _ma, _ge,  -1, _ko, _bu, _si-_ge, _ka @ _ma, _ge, _si, _ko, _bu
-    KeccakP_ThetaRhoPiChi3     _ka, _be,  -1, _go,  -1, _mi-_be, _ga @ _ka, _be, _mi, _go, _su 
+    KeccakP_ThetaRhoPiChi3     _ka, _be,  -1, _go,  -1, _mi-_be, _ga @ _ka, _be, _mi, _go, _su
     KeccakP_ThetaRhoPiChi4     _ga,  -1, _ki, _bo,  -1, _se-_ga, _ba @ _ga, _se, _ki, _bo, _mu
-                                                                       
+
     KeccakP_ThetaRhoPiChiIota  _ba,  -1,  -1, _go,  -1, _ke-_ba, _ma @ _ba, _ke, _si, _go, _mu
     KeccakP_ThetaRhoPiChi1     _ma, _be,  -1,  -1, _gu, _ki-_be, _ga @ _ma, _be, _ki, _so, _gu
     KeccakP_ThetaRhoPiChi2     _ga,  -1, _bi,  -1,  -1, _me-_ga, _sa @ _ga, _me, _bi, _ko, _su
     KeccakP_ThetaRhoPiChi3     _sa, _ge,  -1, _bo,  -1, _mi-_ge, _ka @ _sa, _ge, _mi, _bo, _ku
     KeccakP_ThetaRhoPiChi4     _ka,  -1, _gi,  -1, _bu, _se-_ka, _ba @ _ka, _se, _gi, _mo, _bu
-                                                                       
+
     KeccakP_ThetaRhoPiChiIota  _ba,  -1,  -1,  -1,  -1, _be-_ba, _ga @ _ba, _be, _bi, _bo, _bu
     KeccakP_ThetaRhoPiChi1     _ga,  -1,  -1,  -1,  -1, _ge-_ga, _ka @ _ga, _ge, _gi, _go, _gu
     KeccakP_ThetaRhoPiChi2     _ka,  -1,  -1,  -1,  -1, _ke-_ka, _ma @ _ka, _ke, _ki, _ko, _ku
     KeccakP_ThetaRhoPiChi3     _ma,  -1,  -1,  -1,  -1, _me-_ma, _sa @ _ma, _me, _mi, _mo, _mu
-    subs	r2, #4                                            
+    subs	r2, #4
     KeccakP_ThetaRhoPiChi4     _sa,  -1,  -1,  -1,  -1, _se-_sa, _ba @ _sa, _se, _si, _so, _su
     bne		KeccakF1600_Pl2_PermuteAll_RoundLoop
     add 	sp, #4*2*8+8	@ free 4.5 D lanes
     pop		{r4-r7}
     vpop	{q4-q7}
     bx		lr
-   
+
 

--- a/PlSnP/2/KeccakP-1600-12/OptimizedAsmARM/KeccakP-1600-12-inplace-pl2-armv7a-neon-gcc.s
+++ b/PlSnP/2/KeccakP-1600-12/OptimizedAsmARM/KeccakP-1600-12-inplace-pl2-armv7a-neon-gcc.s
@@ -13,14 +13,14 @@
 @ http://creativecommons.org/publicdomain/zero/1.0/
 @
 
-@ WARNING: These functions work only on little endian CPU with@ ARMv7A + NEON architecture 
+@ WARNING: These functions work only on little endian CPU with@ ARMv7A + NEON architecture
 @ WARNING: State must be 256 bit (32 bytes) aligned, best is 64-byte (cache alignment).
 
 @ INFO: Tested on Cortex-A8 (BeagleBone Black), using gcc.
 @ INFO: Parallel execution of Keccak-F permutation on 2 lane interleaved states.
 
 
-    
+
 .text
 
 @----------------------------------------------------------------------------
@@ -105,7 +105,7 @@
     @ argA2 =   Be ^((~Bi)& Bo )
     @ argA3 =   Bi ^((~Bo)& Bu )
     @ argA4 =   Bo ^((~Bu)& Ba )
-    @ argA5 =   Bu ^((~Ba)& Be ) 
+    @ argA5 =   Bu ^((~Ba)& Be )
     @ argA1 =   Ba ^((~Be)& Bi )
     @ argA1 ^= KeccakF1600RoundConstants[i+round]
     vsri.64     d1,    \argA2,   #64-44
@@ -129,7 +129,7 @@
     vbic.64     \argA4, d0,      d4
     veor.64     \argA2, d1
     vstr.64     d5,    [r0, #\argA1]
-    veor.64     \argA3, d2    
+    veor.64     \argA3, d2
     veor.64     \argA4, d3
     veor.64     \argA5, d4
     .endm
@@ -319,7 +319,7 @@
     vld1.64		{ \qreg }, [r3:128], r4
     .endif
     .endm
-    
+
 .macro    m_st		qreg, next
     .if \next == 16
     vst1.64		{ \qreg }, [r3:128]!
@@ -355,7 +355,7 @@
     .endif
     veor.64		q9,	q9,  q3
     veor.64		q5,	q5,  q4
-    
+
     @ Ba = argA1^Da
     @ Be = ROL64(argA2^De, 44)
     @ Bi = ROL64(argA3^Di, 43)
@@ -394,7 +394,7 @@
     @ argA2 = Be ^(~Bi & Bo)
     @ argA3 = Bi ^(~Bo & Bu)
     @ argA4 = Bo ^(~Bu & Ba)
-    @ argA5 = Bu ^(~Ba & Be) 
+    @ argA5 = Bu ^(~Ba & Be)
     vld1.64		{ d30 },	[r1:64]
     vbic.64		q0,	q12,	q11
     vbic.64		q1,	q13,	q12
@@ -409,7 +409,7 @@
     veor.64	q1,	q11
     m_st	q0, \next
     m_pls	\ofs2
-    veor.64	q2,	q12    
+    veor.64	q2,	q12
     m_st	q1, \next
     m_pls	\ofs3
     veor.64	q3,	q13
@@ -486,7 +486,7 @@
     veor.64	q1,   q1,  q6
     vld1.64	{ q6 }, [r6:128]!
     veor.64	q8,   q8,   q13
-    
+
     m_st	q7, \next
     m_pls	\ofs4
     veor.64	q2,   q2,  q7
@@ -592,9 +592,9 @@
 @
    .align 8
 .global   KeccakF1600_Pl_Initialize
-KeccakF1600_Pl_Initialize:  
+KeccakF1600_Pl_Initialize:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -602,7 +602,7 @@ KeccakF1600_Pl_Initialize:
 @
    .align 8
 .global   KeccakF1600_Pl2_InitializeAll
-KeccakF1600_Pl2_InitializeAll:  
+KeccakF1600_Pl2_InitializeAll:
     vmov.i64	q0, #0
     vmov.i64	q1, #0
     vmov.i64	q2, #0
@@ -615,7 +615,7 @@ KeccakF1600_Pl2_InitializeAll:
     vstm		r0!, { d0 - d7 }      @ 48
     vstm		r0!, { d0 - d1}	      @ 50
     bx			lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -623,7 +623,7 @@ KeccakF1600_Pl2_InitializeAll:
 @
    .align 8
 .global 	KeccakF1600_Pl2_ComplementBit
-KeccakF1600_Pl2_ComplementBit:  
+KeccakF1600_Pl2_ComplementBit:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     lsr		r1, r2, #6					@ states += position / 64 * 2 * 8
     add		r0, r0, r1, LSL #4
@@ -636,7 +636,7 @@ KeccakF1600_Pl2_ComplementBit:
     eor		r2, r2, r3
     str		r2, [r0, r1, LSL #2]
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -644,14 +644,14 @@ KeccakF1600_Pl2_ComplementBit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_ComplementBitAll
-KeccakF1600_Pl2_ComplementBitAll:  
+KeccakF1600_Pl2_ComplementBitAll:
     lsr		r2, r1, #6					@ states += position / 64 * 2 * 8
     add		r0, r0, r2, LSL #4
     lsr 	r2, r1, #5					@ r2 = (position / 32) & 1
     and		r2, r2, #1
     mov 	r3, #1						@ r3 = (1 << (position % 32))
     and		r1, r1, #31
-    add		r0, r0, r2, LSL #2			@ states += 4 * r2 
+    add		r0, r0, r2, LSL #2			@ states += 4 * r2
     lsl		r3, r3, r1
     ldr		r1, [r0]
     ldr		r2, [r0, #8]
@@ -660,16 +660,16 @@ KeccakF1600_Pl2_ComplementBitAll:
     str		r1, [r0]
     str		r2, [r0, #8]
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_XORBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_XORBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global   KeccakF1600_Pl2_XORBytes
-KeccakF1600_Pl2_XORBytes:  
+KeccakF1600_Pl2_XORBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -719,7 +719,7 @@ KeccakF1600_Pl2_XORBytes_Done:
     pop		{ r4- r7 }
 KeccakF1600_Pl2_XORBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -727,7 +727,7 @@ KeccakF1600_Pl2_XORBytes_Exit:
 @
 .global   KeccakF1600_Pl2_XORLanesAll
    .align 8
-KeccakF1600_Pl2_XORLanesAll:  
+KeccakF1600_Pl2_XORLanesAll:
     cmp		r2, #0
     beq		KeccakF1600_Pl2_XORLanesAll_Exit
     add		r3, r1, r3, LSL #3		@ r3: data + 8 * laneOffset
@@ -750,16 +750,16 @@ KeccakF1600_Pl2_XORLanesAll_Loop:
     pop		{r4 - r7}
 KeccakF1600_Pl2_XORLanesAll_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_OverwriteBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_OverwriteBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global 	KeccakF1600_Pl2_OverwriteBytes
-KeccakF1600_Pl2_OverwriteBytes: 
+KeccakF1600_Pl2_OverwriteBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -801,7 +801,7 @@ KeccakF1600_Pl2_OverwriteBytes_Done:
     pop		{ r4- r5 }
 KeccakF1600_Pl2_OverwriteBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -809,7 +809,7 @@ KeccakF1600_Pl2_OverwriteBytes_Exit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_OverwriteLanesAll
-KeccakF1600_Pl2_OverwriteLanesAll: 
+KeccakF1600_Pl2_OverwriteLanesAll:
     cmp		r2, #0
     beq		KeccakF1600_Pl2_OverwriteLanesAll_Exit
     lsls	r12, r1, #32-3
@@ -845,7 +845,7 @@ KeccakF1600_Pl2_OverwriteLanesAll_LoopUnaligned:
     pop		{ r4, r5 }
 KeccakF1600_Pl2_OverwriteLanesAll_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -853,14 +853,14 @@ KeccakF1600_Pl2_OverwriteLanesAll_Exit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_OverwriteWithZeroes
-KeccakF1600_Pl2_OverwriteWithZeroes: 
+KeccakF1600_Pl2_OverwriteWithZeroes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     lsrs	r1, r2, #3					@ r1: laneCount
     beq		KeccakF1600_Pl2_OverwriteWithZeroes_Bytes
     vmov.i64 d0, #0
 KeccakF1600_Pl2_OverwriteWithZeroes_LoopLanes:
     subs	r1, r1, #1
-    vstm    r0!, { d0 }    
+    vstm    r0!, { d0 }
     add		r0, r0, #8
     bne		KeccakF1600_Pl2_OverwriteWithZeroes_LoopLanes
 KeccakF1600_Pl2_OverwriteWithZeroes_Bytes:
@@ -873,16 +873,16 @@ KeccakF1600_Pl2_OverwriteWithZeroes_LoopBytes:
     bne		KeccakF1600_Pl2_OverwriteWithZeroes_LoopBytes
 KeccakF1600_Pl2_OverwriteWithZeroes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_ExtractBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_ExtractBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global 	KeccakF1600_Pl2_ExtractBytes
-KeccakF1600_Pl2_ExtractBytes:  
+KeccakF1600_Pl2_ExtractBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -924,7 +924,7 @@ KeccakF1600_Pl2_ExtractBytes_Done:
     pop		{ r4-r5 }
 KeccakF1600_Pl2_ExtractBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -932,7 +932,7 @@ KeccakF1600_Pl2_ExtractBytes_Exit:
 @
    .align 8
 .global 	KeccakF1600_Pl2_ExtractLanesAll
-KeccakF1600_Pl2_ExtractLanesAll:  
+KeccakF1600_Pl2_ExtractLanesAll:
     cmp		r2, #0
     beq		KeccakF1600_Pl2_ExtractLanesAll_Exit
     lsls	r12, r1, #32-3
@@ -968,16 +968,16 @@ KeccakF1600_Pl2_ExtractLanesAll_LoopUnaligned:
     pop		{ r4, r5 }
 KeccakF1600_Pl2_ExtractLanesAll_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ void KeccakF1600_Pl2_ExtractAndXORBytes( void *states, unsigned int instanceIndex, const unsigned char *data, 
+@ void KeccakF1600_Pl2_ExtractAndXORBytes( void *states, unsigned int instanceIndex, const unsigned char *data,
 @ 								    unsigned int offset, unsigned int length )
 @
    .align 8
 .global 	KeccakF1600_Pl2_ExtractAndXORBytes
-KeccakF1600_Pl2_ExtractAndXORBytes:  
+KeccakF1600_Pl2_ExtractAndXORBytes:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     ldr		r1, [sp, #0*4]				@ r1 = length
     cmp		r1, #0
@@ -1027,7 +1027,7 @@ KeccakF1600_Pl2_ExtractAndXORBytes_Done:
     pop		{ r4- r7 }
 KeccakF1600_Pl2_ExtractAndXORBytes_Exit:
     bx		lr
-   
+
 
 @----------------------------------------------------------------------------
 @
@@ -1091,7 +1091,7 @@ KeccakF1600_Pl2_ExtractAndXORLanesAll_LoopUnaligned:
     pop		{ r4 - r7 }
 KeccakF1600_Pl2_ExtractAndXORLanesAll_Exit:
     bx		lr
-   
+
 
    .align 8
 KeccakP1600_12_Pl2_Permute_RoundConstants:
@@ -1114,7 +1114,7 @@ KeccakP1600_12_Pl2_Permute_RoundConstants:
 @
    .align 8
 .global 	KeccakP1600_12_Pl2_Permute
-KeccakP1600_12_Pl2_Permute:  
+KeccakP1600_12_Pl2_Permute:
     add		r0, r0, r1, LSL #3			@ states += 8 * instanceIndex
     adr		r1, KeccakP1600_12_Pl2_Permute_RoundConstants
     movs	r2, #12
@@ -1192,7 +1192,7 @@ KeccakP1600_12_ParallelPermute_RoundLoop:
     vstr.64 d31, [r0, #_su]
     vpop    {q4-q7}
     bx      lr
-   
+
 
    .align 8
 KeccakP1600_12_Pl2_PermuteAll_RoundConstants:
@@ -1215,7 +1215,7 @@ KeccakP1600_12_Pl2_PermuteAll_RoundConstants:
 @
    .align 8
 .global 	KeccakP1600_12_Pl2_PermuteAll
-KeccakP1600_12_Pl2_PermuteAll:  
+KeccakP1600_12_Pl2_PermuteAll:
     adr		r1, KeccakP1600_12_Pl2_PermuteAll_RoundConstants
     movs	r2, #12
     vpush	{q4-q7}
@@ -1234,76 +1234,76 @@ KeccakP1600_12_Pl2_PermuteAll:
     bic		r5, #15
     vld1.64	{ d4, d5, d6, d7 }, [r3:256]!	@ _bi _bo
     vld1.64	{ d8, d9, d10, d11 }, [r3:256]!	@ _bu _ga
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _ge 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _ge
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _gi
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _go
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _gu 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _gu
     veor.64	q3, q3, q8
     vld1.64	{ d10, d11 }, [r3:128]!	@ _ka
     veor.64	q4, q4, q9
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _ke 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _ke
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _ki
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _ko
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _ku 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _ku
     veor.64	q3, q3, q8
     vld1.64	{ d10, d11 }, [r3:128]!	@ _ma
     veor.64	q4, q4, q9
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _me 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _me
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _mi
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _mo
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _mu 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _mu
     veor.64	q3, q3, q8
     vld1.64	{ d10, d11 }, [r3:128]!	@ _sa
     veor.64	q4, q4, q9
-    vld1.64	{ d12, d13 }, [r3:128]!	@ _se 
+    vld1.64	{ d12, d13 }, [r3:128]!	@ _se
     veor.64	q0, q0, q5
     vld1.64	{ d14, d15 }, [r3:128]!	@ _si
     veor.64	q1, q1, q6
     vld1.64	{ d16, d17 }, [r3:128]!	@ _so
     veor.64	q2, q2, q7
-    vld1.64	{ d18, d19 }, [r3:128]!	@ _su 
+    vld1.64	{ d18, d19 }, [r3:128]!	@ _su
     mov		r3, r0
     veor.64	q3, q3, q8
     veor.64	q4, q4, q9
-    
+
 KeccakP1600_12_Pl2_PermuteAll_RoundLoop:
     KeccakP_ThetaRhoPiChiIota  _ba,  -1,  -1,  -1,  -1, _ge-_ba, _ka @ _ba, _ge, _ki, _mo, _su
     KeccakP_ThetaRhoPiChi1     _ka,  -1,  -1,  _bo, -1, _me-_ka, _sa @ _ka, _me, _si, _bo, _gu
     KeccakP_ThetaRhoPiChi2     _sa, _be,  -1,  -1,  -1, _gi-_be, _ga @ _sa, _be, _gi, _ko, _mu
     KeccakP_ThetaRhoPiChi3     _ga,  -1,  -1,  -1, _bu, _ke-_ga, _ma @ _ga, _ke, _mi, _so, _bu
     KeccakP_ThetaRhoPiChi4     _ma,  -1, _bi,  -1,  -1, _se-_ma, _ba @ _ma, _se, _bi, _go, _ku
-                                                                       
+
     KeccakP_ThetaRhoPiChiIota  _ba,  -1, _gi,  -1, _ku, _me-_ba, _sa @ _ba, _me, _gi, _so, _ku
     KeccakP_ThetaRhoPiChi1     _sa, _ke, _bi,  -1, _gu, _mo-_bi, _ma @ _sa, _ke, _bi, _mo, _gu
     KeccakP_ThetaRhoPiChi2     _ma, _ge,  -1, _ko, _bu, _si-_ge, _ka @ _ma, _ge, _si, _ko, _bu
-    KeccakP_ThetaRhoPiChi3     _ka, _be,  -1, _go,  -1, _mi-_be, _ga @ _ka, _be, _mi, _go, _su 
+    KeccakP_ThetaRhoPiChi3     _ka, _be,  -1, _go,  -1, _mi-_be, _ga @ _ka, _be, _mi, _go, _su
     KeccakP_ThetaRhoPiChi4     _ga,  -1, _ki, _bo,  -1, _se-_ga, _ba @ _ga, _se, _ki, _bo, _mu
-                                                                       
+
     KeccakP_ThetaRhoPiChiIota  _ba,  -1,  -1, _go,  -1, _ke-_ba, _ma @ _ba, _ke, _si, _go, _mu
     KeccakP_ThetaRhoPiChi1     _ma, _be,  -1,  -1, _gu, _ki-_be, _ga @ _ma, _be, _ki, _so, _gu
     KeccakP_ThetaRhoPiChi2     _ga,  -1, _bi,  -1,  -1, _me-_ga, _sa @ _ga, _me, _bi, _ko, _su
     KeccakP_ThetaRhoPiChi3     _sa, _ge,  -1, _bo,  -1, _mi-_ge, _ka @ _sa, _ge, _mi, _bo, _ku
     KeccakP_ThetaRhoPiChi4     _ka,  -1, _gi,  -1, _bu, _se-_ka, _ba @ _ka, _se, _gi, _mo, _bu
-                                                                       
+
     KeccakP_ThetaRhoPiChiIota  _ba,  -1,  -1,  -1,  -1, _be-_ba, _ga @ _ba, _be, _bi, _bo, _bu
     KeccakP_ThetaRhoPiChi1     _ga,  -1,  -1,  -1,  -1, _ge-_ga, _ka @ _ga, _ge, _gi, _go, _gu
     KeccakP_ThetaRhoPiChi2     _ka,  -1,  -1,  -1,  -1, _ke-_ka, _ma @ _ka, _ke, _ki, _ko, _ku
     KeccakP_ThetaRhoPiChi3     _ma,  -1,  -1,  -1,  -1, _me-_ma, _sa @ _ma, _me, _mi, _mo, _mu
-    subs	r2, #4                                            
+    subs	r2, #4
     KeccakP_ThetaRhoPiChi4     _sa,  -1,  -1,  -1,  -1, _se-_sa, _ba @ _sa, _se, _si, _so, _su
     bne		KeccakP1600_12_Pl2_PermuteAll_RoundLoop
     add 	sp, #4*2*8+8	@ free 4.5 D lanes
     pop		{r4-r7}
     vpop	{q4-q7}
     bx		lr
-   
+
 

--- a/SnP/KeccakF-1600/Compact64/KeccakF-1600-compact64.c
+++ b/SnP/KeccakF-1600/Compact64/KeccakF-1600-compact64.c
@@ -51,20 +51,20 @@ typedef UINT64 tKeccakLane;
 
 #define    cKeccakNumberOfRounds    24
 
-const UINT8 KeccakF_RotationConstants[25] = 
+const UINT8 KeccakF_RotationConstants[25] =
 {
      1,  3,  6, 10, 15, 21, 28, 36, 45, 55,  2, 14, 27, 41, 56,  8, 25, 43, 62, 18, 39, 61, 20, 44
 };
 
-const UINT8 KeccakF_PiLane[25] = 
+const UINT8 KeccakF_PiLane[25] =
 {
-    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1 
+    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1
 };
 
 #if    defined(DIVISION_INSTRUCTION)
 #define    MOD5(argValue)    ((argValue) % 5)
 #else
-const UINT8 KeccakF_Mod5[10] = 
+const UINT8 KeccakF_Mod5[10] =
 {
     0, 1, 2, 3, 4, 0, 1, 2, 3, 4
 };
@@ -83,7 +83,7 @@ static tKeccakLane KeccakF1600_GetNextRoundConstant( UINT8 *LFSR )
 
     roundConstant = 0;
     tempLSFR = *LFSR;
-    for(i=1; i<128; i <<= 1) 
+    for(i=1; i<128; i <<= 1)
     {
         doXOR = tempLSFR & 1;
         if ((tempLSFR & 0x80) != 0)

--- a/SnP/KeccakF-1600/Inplace32BI/KeccakF-1600-inplace32BI.c
+++ b/SnP/KeccakF-1600/Inplace32BI/KeccakF-1600-inplace32BI.c
@@ -132,12 +132,12 @@ void KeccakF1600_StateXORBytesInLane(void *state, unsigned int lanePosition, con
     low = *((UINT32*)(laneAsBytes+0));
     high = *((UINT32*)(laneAsBytes+4));
 #else
-    low = laneAsBytes[0] 
-        | ((UINT32)(laneAsBytes[1]) << 8) 
+    low = laneAsBytes[0]
+        | ((UINT32)(laneAsBytes[1]) << 8)
         | ((UINT32)(laneAsBytes[2]) << 16)
         | ((UINT32)(laneAsBytes[3]) << 24);
-    high = laneAsBytes[4] 
-        | ((UINT32)(laneAsBytes[5]) << 8) 
+    high = laneAsBytes[4]
+        | ((UINT32)(laneAsBytes[5]) << 8)
         | ((UINT32)(laneAsBytes[6]) << 16)
         | ((UINT32)(laneAsBytes[7]) << 24);
 #endif
@@ -169,12 +169,12 @@ void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned 
     for(lanePosition=0; lanePosition<laneCount; lanePosition++) {
         UINT8 laneAsBytes[8];
         memcpy(laneAsBytes, data+lanePosition*8, 8);
-        UINT32 low = laneAsBytes[0] 
-            | ((UINT32)(laneAsBytes[1]) << 8) 
+        UINT32 low = laneAsBytes[0]
+            | ((UINT32)(laneAsBytes[1]) << 8)
             | ((UINT32)(laneAsBytes[2]) << 16)
             | ((UINT32)(laneAsBytes[3]) << 24);
-        UINT32 high = laneAsBytes[4] 
-            | ((UINT32)(laneAsBytes[5]) << 8) 
+        UINT32 high = laneAsBytes[4]
+            | ((UINT32)(laneAsBytes[5]) << 8)
             | ((UINT32)(laneAsBytes[6]) << 16)
             | ((UINT32)(laneAsBytes[7]) << 24);
         UINT32 even, odd, temp, temp0, temp1;

--- a/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv6m-le-armcc.s
+++ b/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv6m-le-armcc.s
@@ -245,13 +245,13 @@ mSize	equ 6*4
 
 	load		$result,  0, 		$b, 0
 	load		r1, 	 $b, 		$g, 0
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	load		r1, 	 $g, 		$k, 0
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	load		r1,	 $k, 		$m, 0
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	load		r1,	 $m, 		$s, 1
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	MEND
 
 	MACRO
@@ -690,7 +690,7 @@ KeccakF1600_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -796,7 +796,7 @@ KeccakF1600_StateXORBytesInLane_ToBitInterleavingConstants
 	dcd		0xCCCCCCCC
 	dcd		0xF0F0F0F0
 	dcd		0xFF00FF00
-KeccakF1600_StateXORBytesInLane_LengthNotZero	
+KeccakF1600_StateXORBytesInLane_LengthNotZero
 	mov		r4, r8
 	mov		r5, r9
 	push	{r4 - r5}
@@ -833,7 +833,7 @@ KeccakF1600_StateXORBytesInLane_Loop
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
 	adr		r3, KeccakF1600_StateOverwriteLanes_ToBitInterleavingConstants
 	cmp		r2, #0
 	bne		KeccakF1600_StateOverwriteLanes_LanesNotZero
@@ -928,7 +928,7 @@ KeccakF1600_StateOverwriteBytesInLane_ToBitInterleavingConstants
 	dcd		0xCCCCCCCC
 	dcd		0xF0F0F0F0
 	dcd		0xFF00FF00
-KeccakF1600_StateOverwriteBytesInLane_LengthNotZero	
+KeccakF1600_StateOverwriteBytesInLane_LengthNotZero
 	mov		r4, r8
 	mov		r5, r9
 	push	{r4 - r5}
@@ -974,7 +974,7 @@ KeccakF1600_StateOverwriteBytesInLane_Loop
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -1298,8 +1298,8 @@ KeccakP1600_StatePermute_Done
 ; Keccak_SnP_InterleaveByteAsm
 ; in:  r1   byte to be interleaved
 ;
-; out: r9	Least significant interleaved byte 
-;      r10  Most significant interleaved byte 
+; out: r9	Least significant interleaved byte
+;      r10  Most significant interleaved byte
 ;
 ; changed: r2, r3
 ;
@@ -1336,7 +1336,7 @@ Keccak_SnP_InterleaveByteAsm	PROC
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -1354,7 +1354,7 @@ KeccakF1600_SnP_FBWL_Absorb	PROC
 	bcc		KeccakF1600_SnP_FBWL_Absorb_Exit
 	mov		r4, r0
 	mov		r5, r1
-	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits
 	bl		Keccak_SnP_InterleaveByteAsm
 KeccakF1600_SnP_FBWL_Absorb_Loop
 	mov		r1, r6
@@ -1425,7 +1425,7 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -1444,7 +1444,7 @@ KeccakF1600_SnP_FBWL_Wrap	PROC
 	bcc		KeccakF1600_SnP_FBWL_Wrap_Exit
 	mov		r4, r3							; r4 dataOut pointer
 	mov		r5, r1							; r5 laneCount
-	ldr		r1, [sp, #(8+1)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+1)*4]				; Bit Interleave trailingBits
 	bl		Keccak_SnP_InterleaveByteAsm
 KeccakF1600_SnP_FBWL_Wrap_Loop
 	mov		r1, r6
@@ -1484,7 +1484,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -1508,7 +1508,7 @@ KeccakF1600_SnP_FBWL_Unwrap_Start
 	push	{ r4 - r5 }
 	mov		r4, r3							; r4 dataOut pointer
 	mov		r5, r1							; r5 laneCount
-	ldr		r1, [sp, #(10+1)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; Bit Interleave trailingBits
 	bl		Keccak_SnP_InterleaveByteAsm
 KeccakF1600_SnP_FBWL_Unwrap_Loop
 	mov		lr, r5
@@ -1596,7 +1596,7 @@ KeccakF1600_SnP_FBWL_Unwrap_LanesDone
 	subs	r0, r0, r2
 	bl		KeccakF1600_StatePermute
 	subs	r7, r7, r5						; nbrLanes -= laneCount
-	bcc		KeccakF1600_SnP_FBWL_Unwrap_Done		
+	bcc		KeccakF1600_SnP_FBWL_Unwrap_Done
 	b		KeccakF1600_SnP_FBWL_Unwrap_Loop
 KeccakF1600_SnP_FBWL_Unwrap_Done
 	pop		{ r4 - r5 }

--- a/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv7a-le-armcc.s
+++ b/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv7a-le-armcc.s
@@ -14,7 +14,7 @@
 ;
 
 ; WARNING: These functions work only on little endian CPU with ARMv7a architecture (ARM Cortex-A8, ...).
- 
+
 ; INFO: Tested on a Cortex-A8 (BeagleBone Black)
 
     PRESERVE8
@@ -537,7 +537,7 @@ KeccakF1600_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -609,7 +609,7 @@ KeccakF1600_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
     cmp     r2, #0
     beq     KeccakF1600_StateOverwriteLanes_Exit
     push    {r4 - r11}
@@ -687,7 +687,7 @@ KeccakF1600_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -907,7 +907,7 @@ KeccakF1600_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -921,7 +921,7 @@ KeccakF1600_SnP_FBWL_Absorb	PROC
 	mov		r4, r0
 	mov		r5, r1
 	mov		r6, r2
-	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -985,7 +985,7 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -993,14 +993,14 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit
 KeccakF1600_SnP_FBWL_Wrap	PROC
 	push	{r4-r10,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(8+0)*4]				;  
+	ldr		r4, [sp, #(8+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcc		KeccakF1600_SnP_FBWL_Wrap_Exit
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(8+1)*4]				; r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+1)*4]				; r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1032,7 +1032,7 @@ KeccakF1600_SnP_FBWL_Wrap_Loop
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakF1600_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakF1600_SnP_FBWL_Wrap_Loop
 KeccakF1600_SnP_FBWL_Wrap_Exit
 	mov		r0, r8
@@ -1041,7 +1041,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -1049,7 +1049,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit
 KeccakF1600_SnP_FBWL_Unwrap	PROC
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				;  
+	ldr		r4, [sp, #(10+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcs		KeccakF1600_SnP_FBWL_Unwrap_WorkTodo
@@ -1059,7 +1059,7 @@ KeccakF1600_SnP_FBWL_Unwrap_WorkTodo
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				; r9,r12 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; r9,r12 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1088,7 +1088,7 @@ KeccakF1600_SnP_FBWL_UnwrapLane_Loop1
 	toBitInterleaving	r1, r2, r10, r11, r3, r4, r8, r9, r12, 1
 	ldrd	r2, r3, [r0]
 	strd	r10, r11, [r0], #8
-	eor		r2, r2, r10	
+	eor		r2, r2, r10
 	eor		r3, r3, r11
 	str		r2, [r7], #4
 	str		r3, [r7], #4
@@ -1120,7 +1120,7 @@ KeccakF1600_SnP_FBWL_UnwrapLane_Loop2
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakF1600_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakF1600_SnP_FBWL_Unwrap_Loop
 	mov		r0, r8
 	pop		{r4-r12,pc}

--- a/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv7a-le-gcc.s
+++ b/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv7a-le-gcc.s
@@ -14,10 +14,10 @@
 @
 
 @ WARNING: These functions work only on little endian CPU with@ ARMv7a architecture (ARM Cortex-A8, ...).
- 
+
 @ INFO: Tested on a Cortex-A8 (BeagleBone Black)
 
-   
+
 .text
 
     @// Credit: Henry S. Warren, Hacker's Delight, Addison-Wesley, 2002
@@ -472,7 +472,7 @@
 @//
 .align 8
 .global   KeccakF1600_Initialize
-KeccakF1600_Initialize:  
+KeccakF1600_Initialize:
 	bx		lr
 
 
@@ -482,7 +482,7 @@ KeccakF1600_Initialize:
 @//
 .align 8
 .global   KeccakF1600_StateInitialize
-KeccakF1600_StateInitialize:  
+KeccakF1600_StateInitialize:
 	push	{r4 - r5}
 	movs	r1, #0
 	movs	r2, #0
@@ -509,7 +509,7 @@ KeccakF1600_StateInitialize:
 @//
 .align 8
 .global   KeccakF1600_StateComplementBit
-KeccakF1600_StateComplementBit:  
+KeccakF1600_StateComplementBit:
 	and		r3, r1, #1
 	lsrs	r2, r1, #6
 	add		r0, r0, r3, LSL #2
@@ -526,10 +526,10 @@ KeccakF1600_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF1600_StateXORLanes
-KeccakF1600_StateXORLanes:  
+KeccakF1600_StateXORLanes:
     cmp     r2, #0
     beq     KeccakF1600_StateXORLanes_Exit
     push    {r4 - r11}
@@ -552,7 +552,7 @@ KeccakF1600_StateXORLanes_LoopAligned:
     pop     {r4 - r11}
 KeccakF1600_StateXORLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -560,7 +560,7 @@ KeccakF1600_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateXORBytesInLane
-KeccakF1600_StateXORBytesInLane:  
+KeccakF1600_StateXORBytesInLane:
     push    {r4 - r11}
     ldr     r7, [sp, #8*4]
     cmp     r7, #0
@@ -590,7 +590,7 @@ KeccakF1600_StateXORBytesInLane_Loop:
 KeccakF1600_StateXORBytesInLane_Exit:
     pop     {r4 - r11}
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -598,7 +598,7 @@ KeccakF1600_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes: 
+KeccakF1600_StateOverwriteLanes:
     cmp     r2, #0
     beq     KeccakF1600_StateOverwriteLanes_Exit
     push    {r4 - r11}
@@ -620,7 +620,7 @@ KeccakF1600_StateOverwriteLanes_LoopAligned:
     pop     {r4 - r11}
 KeccakF1600_StateOverwriteLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -668,7 +668,7 @@ KeccakF1600_StateOverwriteBytesInLane_Loop:
     pop     {r4 - r11}
 KeccakF1600_StateOverwriteBytesInLane_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -676,7 +676,7 @@ KeccakF1600_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes: 
+KeccakF1600_StateOverwriteWithZeroes:
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -710,7 +710,7 @@ KeccakF1600_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateExtractLanes
-KeccakF1600_StateExtractLanes:  
+KeccakF1600_StateExtractLanes:
     cmp     r2, #0
     beq     KeccakF1600_StateExtractLanes_Exit
     push    {r4 - r9}
@@ -731,7 +731,7 @@ KeccakF1600_StateExtractLanes_LoopAligned:
     pop     {r4 - r9}
 KeccakF1600_StateExtractLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -739,7 +739,7 @@ KeccakF1600_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateExtractBytesInLane
-KeccakF1600_StateExtractBytesInLane:  
+KeccakF1600_StateExtractBytesInLane:
     push    {r4 - r9}
     ldr     r5, [sp, #6*4]
     cmp     r5, #0
@@ -766,7 +766,7 @@ KeccakF1600_StateExtractBytesInLane_Loop:
 KeccakF1600_StateExtractBytesInLane_Exit:
     pop     {r4 - r9}
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -799,7 +799,7 @@ KeccakF1600_StateExtractAndXORLanes_LoopAligned:
     pop     {r4 - r9}
 KeccakF1600_StateExtractAndXORLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -836,7 +836,7 @@ KeccakF1600_StateExtractAndXORBytesInLane_Loop:
 KeccakF1600_StateExtractAndXORBytesInLane_Exit:
     pop     {r4 - r9}
     bx      lr
-   
+
 
 .align 8
 KeccakF1600_StatePermute_RoundConstantsWithTerminator:
@@ -879,7 +879,7 @@ KeccakF1600_StatePermute_RoundConstantsWithTerminator:
 @//
 .align 8
 .global   KeccakF1600_StatePermute
-KeccakF1600_StatePermute:  
+KeccakF1600_StatePermute:
     adr     r1, KeccakF1600_StatePermute_RoundConstantsWithTerminator
     push    { r4 - r12, lr }
     sub     sp, #mSize
@@ -892,11 +892,11 @@ KeccakF1600_StatePermute_RoundLoop:
     bne     KeccakF1600_StatePermute_RoundLoop
     add     sp, #mSize
     pop     { r4 - r12, pc }
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+@ size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 @										size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -910,7 +910,7 @@ KeccakF1600_SnP_FBWL_Absorb:
 	mov		r4, r0
 	mov		r5, r1
 	mov		r6, r2
-	ldr		r1, [sp, #(8+0)*4]				@ Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				@ Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -974,7 +974,7 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -982,14 +982,14 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit:
 KeccakF1600_SnP_FBWL_Wrap:
 	push	{r4-r10,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(8+0)*4]				@  
+	ldr		r4, [sp, #(8+0)*4]				@
 	lsr		r4, r4, #3						@ r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						@ .if (nbrLanes >== laneCount)
 	bcc		KeccakF1600_SnP_FBWL_Wrap_Exit
 	mov		r5, r1							@ r5: laneCount
 	mov		r6, r2							@ r6: dataIn
 	mov		r7, r3							@ r7: dataOut
-	ldr		r1, [sp, #(8+1)*4]				@ r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+1)*4]				@ r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1021,7 +1021,7 @@ KeccakF1600_SnP_FBWL_Wrap_Loop:
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					@ state pointer back to initial position
 	bl		KeccakF1600_StatePermute
-	subs	r4, r4, r5						@ dec nbrLanes 
+	subs	r4, r4, r5						@ dec nbrLanes
 	bcs		KeccakF1600_SnP_FBWL_Wrap_Loop
 KeccakF1600_SnP_FBWL_Wrap_Exit:
 	mov		r0, r8
@@ -1030,7 +1030,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 @
 .align 8
@@ -1038,7 +1038,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit:
 KeccakF1600_SnP_FBWL_Unwrap:
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				@  
+	ldr		r4, [sp, #(10+0)*4]				@
 	lsr		r4, r4, #3						@ r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						@ .if (nbrLanes >== laneCount)
 	bcs		KeccakF1600_SnP_FBWL_Unwrap_WorkTodo
@@ -1048,7 +1048,7 @@ KeccakF1600_SnP_FBWL_Unwrap_WorkTodo:
 	mov		r5, r1							@ r5: laneCount
 	mov		r6, r2							@ r6: dataIn
 	mov		r7, r3							@ r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				@ r9,r12 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				@ r9,r12 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1077,7 +1077,7 @@ KeccakF1600_SnP_FBWL_UnwrapLane_Loop1:
 	toBitInterleaving	r1, r2, r10, r11, r3, r4, r8, r9, r12, 1
 	ldrd	r2, r3, [r0]
 	strd	r10, r11, [r0], #8
-	eor		r2, r2, r10	
+	eor		r2, r2, r10
 	eor		r3, r3, r11
 	str		r2, [r7], #4
 	str		r3, [r7], #4
@@ -1109,7 +1109,7 @@ KeccakF1600_SnP_FBWL_UnwrapLane_Loop2:
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					@ state pointer back to initial position
 	bl		KeccakF1600_StatePermute
-	subs	r4, r4, r5						@ dec nbrLanes 
+	subs	r4, r4, r5						@ dec nbrLanes
 	bcs		KeccakF1600_SnP_FBWL_Unwrap_Loop
 	mov		r0, r8
 	pop		{r4-r12,pc}

--- a/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv7m-le-armcc.s
+++ b/SnP/KeccakF-1600/Optimized32biAsmARM/KeccakF-1600-inplace-32bi-armv7m-le-armcc.s
@@ -190,11 +190,11 @@ mSize	equ 6*4
 
 	ldr			$result, [r0, #$b]
 	ldr			r1, [r0, #$g]
-	eors		$result, $result, r1				
+	eors		$result, $result, r1
 	ldr			r1, [r0, #$k]
 	eors		$result, $result, r1
 	ldr			r1, [r0, #$m]
-	eors		$result, $result, r1				
+	eors		$result, $result, r1
 	ldr			r1, [r0, #$s]
 	eors		$result, $result, r1
 	MEND
@@ -537,7 +537,7 @@ KeccakF1600_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -593,7 +593,7 @@ KeccakF1600_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
 	cmp		r2, #0
 	beq		KeccakF1600_StateOverwriteLanes_Exit
 	push	{r4 - r7}
@@ -655,7 +655,7 @@ KeccakF1600_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -847,7 +847,7 @@ KeccakF1600_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -861,7 +861,7 @@ KeccakF1600_SnP_FBWL_Absorb	PROC
 	mov		r4, r0
 	mov		r5, r1
 	mov		r6, r2
-	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -925,7 +925,7 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -933,7 +933,7 @@ KeccakF1600_SnP_FBWL_Squeeze_Exit
 KeccakF1600_SnP_FBWL_Wrap	PROC
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				;  
+	ldr		r4, [sp, #(10+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcs		KeccakF1600_SnP_FBWL_Wrap_Go
@@ -942,7 +942,7 @@ KeccakF1600_SnP_FBWL_Wrap_Go
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -975,7 +975,7 @@ KeccakF1600_SnP_FBWL_WrapLane_Loop
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakF1600_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakF1600_SnP_FBWL_Wrap_Loop
 KeccakF1600_SnP_FBWL_Wrap_Exit
 	mov		r0, r8
@@ -984,7 +984,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -992,7 +992,7 @@ KeccakF1600_SnP_FBWL_Wrap_Exit
 KeccakF1600_SnP_FBWL_Unwrap	PROC
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				;  
+	ldr		r4, [sp, #(10+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcs		KeccakF1600_SnP_FBWL_Unwrap_Go
@@ -1001,7 +1001,7 @@ KeccakF1600_SnP_FBWL_Unwrap_Go
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1038,7 +1038,7 @@ KeccakF1600_SnP_FBWL_UnwrapLane_Loop
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakF1600_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakF1600_SnP_FBWL_Unwrap_Loop
 KeccakF1600_SnP_FBWL_Unwrap_Exit
 	mov		r0, r8

--- a/SnP/KeccakF-1600/OptimizedAsmARM/KeccakF-1600-armv7a-le-neon-armcc.s
+++ b/SnP/KeccakF-1600/OptimizedAsmARM/KeccakF-1600-armv7a-le-neon-armcc.s
@@ -13,7 +13,7 @@
 ; http://creativecommons.org/publicdomain/zero/1.0/
 ;
 
-; WARNING: These functions work only on little endian CPU with ARMv7A + NEON architecture 
+; WARNING: These functions work only on little endian CPU with ARMv7A + NEON architecture
 ; WARNING: State must be 256 bit (32 bytes) aligned, best is 64-byte (cache alignment).
 ; INFO: Tested on Cortex-A8 (BeagleBone Black), using gcc.
 
@@ -145,7 +145,7 @@ _su		equ 24*8
 	MEND
 
     MACRO
-    KeccakRound	
+    KeccakRound
 
     ;Prepare Theta
     veor.64     q13, q0, q5
@@ -224,16 +224,16 @@ _su		equ 24*8
 
 	RhoPi4		d2, d3, 44, d4, d14, 43, d8, d24, 14, d6, d17, 21	;  1 <  6,  2 < 12,  4 < 24,  3 < 18
 	RhoPi4		d3, d9, 20, d14, d16, 25, d24, d21,  2, d17, d15, 15	;  6 <  9, 12 < 13, 24 < 21, 18 < 17
-	RhoPi4		d9, d22, 61, d16, d19,  8, d21, d7, 55, d15, d12, 10	;  9 < 22, 13 < 19, 21 <  8, 17 < 11	
+	RhoPi4		d9, d22, 61, d16, d19,  8, d21, d7, 55, d15, d12, 10	;  9 < 22, 13 < 19, 21 <  8, 17 < 11
 	RhoPi4		d22, d18, 39, d19, d23, 56, d7, d13, 45, d12, d5,  6	; 22 < 14, 19 < 23,  8 < 16, 11 < 7
 	RhoPi4		d18, d20, 18, d23, d11, 41, d13, d1, 36, d5, d10,  3	; 14 < 20, 23 < 15, 16 <  5,  7 < 10
 	RhoPi4		d20, d28, 62, d11, d25, 27, d1, d29, 28, d10, d27,  1	; 20 <  2, 15 <  4,  5 <  3, 10 < 1
-	
+
 	;Chi	b+g
-	vmov.i64	q13, q0			
+	vmov.i64	q13, q0
     vbic.64     q15, q2, q1	; ba ^= ~be & bi
 	veor.64		q0, q15
-	vmov.i64	q14, q1			
+	vmov.i64	q14, q1
     vbic.64     q15, q3, q2	; be ^= ~bi & bo
 	veor.64		q1, q15
     vbic.64     q15, q4, q3	; bi ^= ~bo & bu
@@ -244,10 +244,10 @@ _su		equ 24*8
  	veor.64		q4, q13
 
 	;Chi	k+m
-	vmov.i64	q13, q5			
+	vmov.i64	q13, q5
     vbic.64     q15, q7, q6	; ba ^= ~be & bi
 	veor.64		q5, q15
-	vmov.i64	q14, q6			
+	vmov.i64	q14, q6
     vbic.64     q15, q8, q7	; be ^= ~bi & bo
 	veor.64		q6, q15
     vbic.64     q15, q9, q8	; bi ^= ~bo & bu
@@ -258,7 +258,7 @@ _su		equ 24*8
  	veor.64		q9, q13
 
 	;Chi	s
-	vmov.i64	q13, q10			
+	vmov.i64	q13, q10
     vbic.64     d30,  d22,  d21	; ba ^= ~be & bi
     vbic.64     d31,  d23,  d22	; be ^= ~bi & bo
 	veor.64		q10, q15
@@ -295,7 +295,7 @@ KeccakF1600_StateInitialize   PROC
     vstm        r0!, { d0 - d7 }            ; clear 8 lanes at a time
     vstm        r0!, { d0 - d7 }
     vstm        r0!, { d0 - d7 }
-    vstm        r0!, { d0 }    
+    vstm        r0!, { d0 }
     bx          lr
     ENDP
 
@@ -319,7 +319,7 @@ KeccakF1600_StateComplementBit   PROC
 ;----------------------------------------------------------------------------
 ;
 ; void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-; 
+;
     ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -369,7 +369,7 @@ KeccakF1600_StateXORBytesInLane_Exit
 ;
     ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
     cmp     r2, #0
     beq     KeccakF1600_StateOverwriteLanes_Exit
     push    {r4 - r5}
@@ -411,13 +411,13 @@ KeccakF1600_StateOverwriteBytesInLane_Exit
 ;
     ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
     vmov.i64 d0, #0
 KeccakF1600_StateOverwriteWithZeroes_LoopLanes
 	subs	r2, r2, #1
-    vstm    r0!, { d0 }    
+    vstm    r0!, { d0 }
 	bne		KeccakF1600_StateOverwriteWithZeroes_LoopLanes
 KeccakF1600_StateOverwriteWithZeroes_Bytes
 	ands	r1, #7
@@ -674,7 +674,7 @@ KeccakF1600_StatePermute   PROC
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF1600_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -966,7 +966,7 @@ KeccakF1600_SnP_FBWL_Squeeze_LoopLessThan16Lanes
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -997,54 +997,54 @@ KeccakF1600_SnP_FBWL_Wrap_Loop21Lanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
-    vst1.64	{ d2 }, [r3]!	
-    vst1.64	{ d4 }, [r3]!	
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
+    vst1.64	{ d2 }, [r3]!
+    vst1.64	{ d4 }, [r3]!
+    vst1.64	{ d6 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d8, d8, d26
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
-    vst1.64	{ d1 }, [r3]!	
-    vst1.64	{ d3 }, [r3]!	
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
+    vst1.64	{ d1 }, [r3]!
+    vst1.64	{ d3 }, [r3]!
+    vst1.64	{ d5 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d7, d7, d26
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
-    vst1.64	{ d9 }, [r3]!	
-    vst1.64	{ d10 }, [r3]!	
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
+    vst1.64	{ d9 }, [r3]!
+    vst1.64	{ d10 }, [r3]!
+    vst1.64	{ d12 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d14, d14, d26
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
-    vst1.64	{ d16 }, [r3]!	
-    vst1.64	{ d18 }, [r3]!	
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
+    vst1.64	{ d16 }, [r3]!
+    vst1.64	{ d18 }, [r3]!
+    vst1.64	{ d11 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d13, d13, d26
 	veor.64	d15, d15, d27
 	veor.64	d17, d17, d28
 	veor.64	d19, d19, d29
-    vst1.64	{ d13 }, [r3]!	
-    vst1.64	{ d15 }, [r3]!	
-    vst1.64	{ d17 }, [r3]!	
-    vst1.64	{ d19 }, [r3]!	
+    vst1.64	{ d13 }, [r3]!
+    vst1.64	{ d15 }, [r3]!
+    vst1.64	{ d17 }, [r3]!
+    vst1.64	{ d19 }, [r3]!
 
     vld1.64	{ d26 }, [r6]!
 	veor.64	d20, d20, d26
-    vst1.64	{ d20 }, [r3]!	
+    vst1.64	{ d20 }, [r3]!
 
 	vld1.64	{d30}, [sp:64]					; xor trailingBits
 	veor.64	d21, d21, d30
@@ -1068,40 +1068,40 @@ KeccakF1600_SnP_FBWL_Wrap_Loop16OrMoreLanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
-    vst1.64	{ d2 }, [r3]!	
-    vst1.64	{ d4 }, [r3]!	
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
+    vst1.64	{ d2 }, [r3]!
+    vst1.64	{ d4 }, [r3]!
+    vst1.64	{ d6 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d8, d8, d26
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
-    vst1.64	{ d1 }, [r3]!	
-    vst1.64	{ d3 }, [r3]!	
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
+    vst1.64	{ d1 }, [r3]!
+    vst1.64	{ d3 }, [r3]!
+    vst1.64	{ d5 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d7, d7, d26
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
-    vst1.64	{ d9 }, [r3]!	
-    vst1.64	{ d10 }, [r3]!	
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
+    vst1.64	{ d9 }, [r3]!
+    vst1.64	{ d10 }, [r3]!
+    vst1.64	{ d12 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d14, d14, d26
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
-    vst1.64	{ d16 }, [r3]!	
-    vst1.64	{ d18 }, [r3]!	
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
+    vst1.64	{ d16 }, [r3]!
+    vst1.64	{ d18 }, [r3]!
+    vst1.64	{ d11 }, [r3]!
 
 	sub		r2, r5, #16							; XOR last n lanes, maximum 9
 	rsb		r1, r2, #9
@@ -1213,7 +1213,7 @@ KeccakF1600_SnP_FBWL_Wrap_LoopLessThan16Lanes
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -1244,13 +1244,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
 	vmov.64	d0, d26
-    vst1.64	{ d2 }, [r3]!	
+    vst1.64	{ d2 }, [r3]!
 	vmov.64	d2, d27
-    vst1.64	{ d4 }, [r3]!	
+    vst1.64	{ d4 }, [r3]!
 	vmov.64	d4, d28
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d6 }, [r3]!
 	vmov.64	d6, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1258,13 +1258,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
 	vmov.64	d8, d26
-    vst1.64	{ d1 }, [r3]!	
+    vst1.64	{ d1 }, [r3]!
 	vmov.64	d1, d27
-    vst1.64	{ d3 }, [r3]!	
+    vst1.64	{ d3 }, [r3]!
 	vmov.64	d3, d28
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d5 }, [r3]!
 	vmov.64	d5, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1272,13 +1272,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
 	vmov.64	d7, d26
-    vst1.64	{ d9 }, [r3]!	
+    vst1.64	{ d9 }, [r3]!
 	vmov.64	d9, d27
-    vst1.64	{ d10 }, [r3]!	
+    vst1.64	{ d10 }, [r3]!
 	vmov.64	d10, d28
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d12 }, [r3]!
 	vmov.64	d12, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1286,13 +1286,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
 	vmov.64	d14, d26
-    vst1.64	{ d16 }, [r3]!	
+    vst1.64	{ d16 }, [r3]!
 	vmov.64	d16, d27
-    vst1.64	{ d18 }, [r3]!	
+    vst1.64	{ d18 }, [r3]!
 	vmov.64	d18, d28
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d11 }, [r3]!
 	vmov.64	d11, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1300,18 +1300,18 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d15, d15, d27
 	veor.64	d17, d17, d28
 	veor.64	d19, d19, d29
-    vst1.64	{ d13 }, [r3]!	
+    vst1.64	{ d13 }, [r3]!
 	vmov.64	d13, d26
-    vst1.64	{ d15 }, [r3]!	
+    vst1.64	{ d15 }, [r3]!
 	vmov.64	d15, d27
-    vst1.64	{ d17 }, [r3]!	
+    vst1.64	{ d17 }, [r3]!
 	vmov.64	d17, d28
-    vst1.64	{ d19 }, [r3]!	
+    vst1.64	{ d19 }, [r3]!
 	vmov.64	d19, d29
 
     vld1.64	{ d26 }, [r6]!
 	veor.64	d20, d20, d26
-    vst1.64	{ d20 }, [r3]!	
+    vst1.64	{ d20 }, [r3]!
 	vmov.64	d20, d26
 
 	vld1.64	{d30}, [sp:64]					; xor trailingBits
@@ -1336,13 +1336,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
 	vmov.64	d0, d26
-    vst1.64	{ d2 }, [r3]!	
+    vst1.64	{ d2 }, [r3]!
 	vmov.64	d2, d27
-    vst1.64	{ d4 }, [r3]!	
+    vst1.64	{ d4 }, [r3]!
 	vmov.64	d4, d28
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d6 }, [r3]!
 	vmov.64	d6, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1350,13 +1350,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
 	vmov.64	d8, d26
-    vst1.64	{ d1 }, [r3]!	
+    vst1.64	{ d1 }, [r3]!
 	vmov.64	d1, d27
-    vst1.64	{ d3 }, [r3]!	
+    vst1.64	{ d3 }, [r3]!
 	vmov.64	d3, d28
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d5 }, [r3]!
 	vmov.64	d5, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1364,13 +1364,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
 	vmov.64	d7, d26
-    vst1.64	{ d9 }, [r3]!	
+    vst1.64	{ d9 }, [r3]!
 	vmov.64	d9, d27
-    vst1.64	{ d10 }, [r3]!	
+    vst1.64	{ d10 }, [r3]!
 	vmov.64	d10, d28
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d12 }, [r3]!
 	vmov.64	d12, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1378,13 +1378,13 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
 	vmov.64	d14, d26
-    vst1.64	{ d16 }, [r3]!	
+    vst1.64	{ d16 }, [r3]!
 	vmov.64	d16, d27
-    vst1.64	{ d18 }, [r3]!	
+    vst1.64	{ d18 }, [r3]!
 	vmov.64	d18, d28
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d11 }, [r3]!
 	vmov.64	d11, d29
 
 	sub		r2, r5, #16							; XOR last n lanes, maximum 9

--- a/SnP/KeccakF-1600/OptimizedAsmAVR8/KeccakF-1600-avr8-compact.s
+++ b/SnP/KeccakF-1600/OptimizedAsmAVR8/KeccakF-1600-avr8-compact.s
@@ -691,7 +691,7 @@ Keccak_Done:
     ret
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakF-1600/OptimizedAsmAVR8/KeccakF-1600-avr8-fast.s
+++ b/SnP/KeccakF-1600/OptimizedAsmAVR8/KeccakF-1600-avr8-fast.s
@@ -1077,7 +1077,7 @@ rotate64_7byte_left:
     #undef  pRound
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakF-1600/OptimizedAsmX86-64/KeccakF-1600-x86-64-gas.s
+++ b/SnP/KeccakF-1600/OptimizedAsmX86-64/KeccakF-1600-x86-64-gas.s
@@ -79,7 +79,7 @@
 .equ rDo, %r8
 .equ rDu, %r9
 
-.equ rBa, %r10 
+.equ rBa, %r10
 .equ rBe, %r11
 .equ rBi, %r12
 .equ rBo, %r13
@@ -125,7 +125,7 @@
     xorq    rCi, rDo
     rolq    rDu
 
-    # Theta Rho Pi Chi Iota, result b 
+    # Theta Rho Pi Chi Iota, result b
     movq    _ba(\iState), rBa
     movq    _ge(\iState), rBe
     xorq    rCo, rDu
@@ -170,7 +170,7 @@
     movq    rBi, rCe
     .endif
 
-    # Theta Rho Pi Chi, result g 
+    # Theta Rho Pi Chi, result g
     movq    _gu(\iState), rBe
     xorq    rDu, rBe
     movq    _ka(\iState), rBi
@@ -375,27 +375,27 @@
 
     subq    $8*25, %rsp
 
-    movq    _ba(rpState), rCa             
+    movq    _ba(rpState), rCa
     movq    _be(rpState), rCe
     movq    _bu(rpState), rCu
 
-    xorq    _ga(rpState), rCa             
+    xorq    _ga(rpState), rCa
     xorq    _ge(rpState), rCe
-    xorq    _gu(rpState), rCu             
+    xorq    _gu(rpState), rCu
 
-    xorq    _ka(rpState), rCa             
+    xorq    _ka(rpState), rCa
     xorq    _ke(rpState), rCe
-    xorq    _ku(rpState), rCu             
+    xorq    _ku(rpState), rCu
 
-    xorq    _ma(rpState), rCa             
+    xorq    _ma(rpState), rCa
     xorq    _me(rpState), rCe
-    xorq    _mu(rpState), rCu             
+    xorq    _mu(rpState), rCu
 
     xorq    _sa(rpState), rCa
     xorq    _se(rpState), rCe
     movq    _si(rpState), rDi
     movq    _so(rpState), rDo
-    xorq    _su(rpState), rCu             
+    xorq    _su(rpState), rCu
 
     mKeccakRound    rpState, rpStack, 0x0000000000000001, 0
     mKeccakRound    rpStack, rpState, 0x0000000000008082, 0
@@ -578,7 +578,7 @@ KeccakF1600_StateInitialize:
 
 KeccakPowerOf2:
     .byte   1, 2, 4, 8, 16, 32, 64, 128
-   
+
 #----------------------------------------------------------------------------
 #
 #    void KeccakF1600_StateComplementBit(void *state, unsigned int position)
@@ -599,7 +599,7 @@ KeccakF1600_StateComplementBit:
 #----------------------------------------------------------------------------
 #
 # void KeccakF1600_StateXORBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
-# 
+#
     .size   KeccakF1600_StateXORBytes, .-KeccakF1600_StateXORBytes
     .align  8
     .global KeccakF1600_StateXORBytes
@@ -856,7 +856,7 @@ KeccakF1600_StatePermute:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakF1600_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data, 
+# size_t KeccakF1600_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data,
 #                                     size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakF1600_SnP_FBWL_Absorb, .-KeccakF1600_SnP_FBWL_Absorb
@@ -937,7 +937,7 @@ KeccakF1600_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg2
     pushq   arg1
     movq    arg2, arg4                  # prepare xor call: length (in bytes)
-    shlq    $3, arg4                    
+    shlq    $3, arg4
     movq    arg3, arg2                  # data pointer
     xorq    arg3, arg3                  # offset = 0
     callq   KeccakF1600_StateXORBytes   #  (void *state, const unsigned char *data, unsigned int offset, unsigned int length)
@@ -948,7 +948,7 @@ KeccakF1600_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg3
     callq   KeccakF1600_StatePermute
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg4
     subq    arg2, arg4                  # while (nbrLanes >= 21)
     jnc     KeccakF1600_SnP_FBWL_Absorb_VariableLaneCountLoop
@@ -975,12 +975,12 @@ KeccakF1600_SnP_FBWL_Squeeze_Loop21:    # Fixed laneCount = 21 (rate = 1344, cap
     pushq   arg3
     mKeccakPermutationInlinable
     popq    arg3
-    
+
     movq    _ba(arg1), rT1a
     movq    _be(arg1), rT1e
     movq    _bi(arg1), rT1i
     movq    _bo(arg1), rT1o
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _bu(arg1), rT1u
     movq    rT1a, _ba(arg3)
@@ -1060,7 +1060,7 @@ KeccakF1600_SnP_FBWL_Squeeze_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                   unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakF1600_SnP_FBWL_Wrap, .-KeccakF1600_SnP_FBWL_Wrap
@@ -1092,7 +1092,7 @@ KeccakF1600_SnP_FBWL_Wrap_Loop21:       # Fixed laneCount = 21 (rate = 1344, cap
     movq    rT1i, _bi(arg1)
     movq    rT1o, _bo(arg1)
     movq    rT1u, _bu(arg1)
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    rT1a, _ba(arg4)
     movq    rT1e, _be(arg4)
@@ -1225,7 +1225,7 @@ KeccakF1600_SnP_FBWL_Wrap_VariableLaneCountLoop:
     popq    arg4
     popq    arg3
 
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakF1600_SnP_FBWL_Wrap_VariableLaneCountLoop
@@ -1233,7 +1233,7 @@ KeccakF1600_SnP_FBWL_Wrap_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                     unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 #
     .size   KeccakF1600_SnP_FBWL_Unwrap, .-KeccakF1600_SnP_FBWL_Unwrap
@@ -1257,7 +1257,7 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21:     # Fixed laneCount = 21 (rate = 1344, cap
     movq    _bi(arg3), rT1i
     movq    _bo(arg3), rT1o
     movq    _bu(arg3), rT1u
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _ba(arg1), rT2a
     movq    _be(arg1), rT2e
@@ -1414,7 +1414,7 @@ KeccakF1600_SnP_FBWL_Unwrap_VariableLaneCount_LaneLoop:
     callq   KeccakF1600_StatePermute
     popq    arg4
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakF1600_SnP_FBWL_Unwrap_VariableLaneCountLoop

--- a/SnP/KeccakF-1600/OptimizedAsmX86-64/KeccakF-1600-x86-64-shld-gas.s
+++ b/SnP/KeccakF-1600/OptimizedAsmX86-64/KeccakF-1600-x86-64-shld-gas.s
@@ -79,7 +79,7 @@
 .equ rDo,		%r8
 .equ rDu,		%r9
 
-.equ rBa,		%r10 
+.equ rBa,		%r10
 .equ rBe,		%r11
 .equ rBi,		%r12
 .equ rBo,		%r13
@@ -125,7 +125,7 @@
     xorq    rCi, rDo
     shld    $1, rDu, rDu
 
-    # Theta Rho Pi Chi Iota, result b 
+    # Theta Rho Pi Chi Iota, result b
     movq    _ba(\iState), rBa
     movq    _ge(\iState), rBe
     xorq    rCo, rDu
@@ -170,7 +170,7 @@
     movq    rBi, rCe
     .endif
 
-    # Theta Rho Pi Chi, result g 
+    # Theta Rho Pi Chi, result g
     movq    _gu(\iState), rBe
     xorq    rDu, rBe
     movq    _ka(\iState), rBi
@@ -375,27 +375,27 @@
 
     subq    $8*25, %rsp
 
-    movq    _ba(rpState), rCa             
+    movq    _ba(rpState), rCa
     movq    _be(rpState), rCe
     movq    _bu(rpState), rCu
 
-    xorq    _ga(rpState), rCa             
+    xorq    _ga(rpState), rCa
     xorq    _ge(rpState), rCe
-    xorq    _gu(rpState), rCu             
+    xorq    _gu(rpState), rCu
 
-    xorq    _ka(rpState), rCa             
+    xorq    _ka(rpState), rCa
     xorq    _ke(rpState), rCe
-    xorq    _ku(rpState), rCu             
+    xorq    _ku(rpState), rCu
 
-    xorq    _ma(rpState), rCa             
+    xorq    _ma(rpState), rCa
     xorq    _me(rpState), rCe
-    xorq    _mu(rpState), rCu             
+    xorq    _mu(rpState), rCu
 
     xorq    _sa(rpState), rCa
     xorq    _se(rpState), rCe
     movq    _si(rpState), rDi
     movq    _so(rpState), rDo
-    xorq    _su(rpState), rCu             
+    xorq    _su(rpState), rCu
 
     mKeccakRound    rpState, rpStack, 0x0000000000000001, 0
     mKeccakRound    rpStack, rpState, 0x0000000000008082, 0
@@ -578,7 +578,7 @@ KeccakF1600_StateInitialize:
 
 KeccakPowerOf2:
     .byte   1, 2, 4, 8, 16, 32, 64, 128
-   
+
 #----------------------------------------------------------------------------
 #
 #    void KeccakF1600_StateComplementBit(void *state, unsigned int position)
@@ -599,7 +599,7 @@ KeccakF1600_StateComplementBit:
 #----------------------------------------------------------------------------
 #
 # void KeccakF1600_StateXORBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
-# 
+#
     .size   KeccakF1600_StateXORBytes, .-KeccakF1600_StateXORBytes
     .align  8
     .global KeccakF1600_StateXORBytes
@@ -856,7 +856,7 @@ KeccakF1600_StatePermute:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakF1600_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data, 
+# size_t KeccakF1600_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data,
 #                                     size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakF1600_SnP_FBWL_Absorb, .-KeccakF1600_SnP_FBWL_Absorb
@@ -937,7 +937,7 @@ KeccakF1600_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg2
     pushq   arg1
     movq    arg2, arg4                  # prepare xor call: length (in bytes)
-    shlq    $3, arg4                    
+    shlq    $3, arg4
     movq    arg3, arg2                  # data pointer
     xorq    arg3, arg3                  # offset = 0
     callq   KeccakF1600_StateXORBytes   #  (void *state, const unsigned char *data, unsigned int offset, unsigned int length)
@@ -948,7 +948,7 @@ KeccakF1600_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg3
     callq   KeccakF1600_StatePermute
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg4
     subq    arg2, arg4                  # while (nbrLanes >= 21)
     jnc     KeccakF1600_SnP_FBWL_Absorb_VariableLaneCountLoop
@@ -975,12 +975,12 @@ KeccakF1600_SnP_FBWL_Squeeze_Loop21:    # Fixed laneCount = 21 (rate = 1344, cap
     pushq   arg3
     mKeccakPermutationInlinable
     popq    arg3
-    
+
     movq    _ba(arg1), rT1a
     movq    _be(arg1), rT1e
     movq    _bi(arg1), rT1i
     movq    _bo(arg1), rT1o
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _bu(arg1), rT1u
     movq    rT1a, _ba(arg3)
@@ -1060,7 +1060,7 @@ KeccakF1600_SnP_FBWL_Squeeze_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakF1600_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                   unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakF1600_SnP_FBWL_Wrap, .-KeccakF1600_SnP_FBWL_Wrap
@@ -1092,7 +1092,7 @@ KeccakF1600_SnP_FBWL_Wrap_Loop21:       # Fixed laneCount = 21 (rate = 1344, cap
     movq    rT1i, _bi(arg1)
     movq    rT1o, _bo(arg1)
     movq    rT1u, _bu(arg1)
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    rT1a, _ba(arg4)
     movq    rT1e, _be(arg4)
@@ -1225,7 +1225,7 @@ KeccakF1600_SnP_FBWL_Wrap_VariableLaneCountLoop:
     popq    arg4
     popq    arg3
 
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakF1600_SnP_FBWL_Wrap_VariableLaneCountLoop
@@ -1233,7 +1233,7 @@ KeccakF1600_SnP_FBWL_Wrap_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakF1600_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                     unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 #
     .size   KeccakF1600_SnP_FBWL_Unwrap, .-KeccakF1600_SnP_FBWL_Unwrap
@@ -1257,7 +1257,7 @@ KeccakF1600_SnP_FBWL_Unwrap_Loop21:     # Fixed laneCount = 21 (rate = 1344, cap
     movq    _bi(arg3), rT1i
     movq    _bo(arg3), rT1o
     movq    _bu(arg3), rT1u
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _ba(arg1), rT2a
     movq    _be(arg1), rT2e
@@ -1414,7 +1414,7 @@ KeccakF1600_SnP_FBWL_Unwrap_VariableLaneCount_LaneLoop:
     callq   KeccakF1600_StatePermute
     popq    arg4
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakF1600_SnP_FBWL_Unwrap_VariableLaneCountLoop

--- a/SnP/KeccakF-1600/Reference/KeccakF-1600-reference.c
+++ b/SnP/KeccakF-1600/Reference/KeccakF-1600-reference.c
@@ -126,7 +126,7 @@ void KeccakF1600_StateComplementBit(void *state, unsigned int position)
     if (position < 1600) {
         unsigned int bytePosition = position/8;
         unsigned int bitPosition = position%8;
-        
+
         ((unsigned char *)state)[bytePosition] ^= (UINT8)1 << bitPosition;
     }
 }
@@ -218,8 +218,8 @@ void theta(tKeccakLane *A)
     tKeccakLane C[5], D[5];
 
     for(x=0; x<5; x++) {
-        C[x] = 0; 
-        for(y=0; y<5; y++) 
+        C[x] = 0;
+        for(y=0; y<5; y++)
             C[x] ^= A[index(x, y)];
     }
     for(x=0; x<5; x++)
@@ -253,7 +253,7 @@ void chi(tKeccakLane *A)
     unsigned int x, y;
     tKeccakLane C[5];
 
-    for(y=0; y<5; y++) { 
+    for(y=0; y<5; y++) {
         for(x=0; x<5; x++)
             C[x] = A[index(x, y)] ^ ((~A[index(x+1, y)]) & A[index(x+2, y)]);
         for(x=0; x<5; x++)

--- a/SnP/KeccakF-1600/Reference/KeccakF-1600-reference32BI.c
+++ b/SnP/KeccakF-1600/Reference/KeccakF-1600-reference32BI.c
@@ -151,12 +151,12 @@ void KeccakF1600_StateXORBytesInLane(void *state, unsigned int lanePosition, con
 
         memset(laneAsBytes, 0, 8);
         memcpy(laneAsBytes+offset, data, length);
-        low = laneAsBytes[0] 
-            | ((UINT32)(laneAsBytes[1]) << 8) 
+        low = laneAsBytes[0]
+            | ((UINT32)(laneAsBytes[1]) << 8)
             | ((UINT32)(laneAsBytes[2]) << 16)
             | ((UINT32)(laneAsBytes[3]) << 24);
-        high = laneAsBytes[4] 
-            | ((UINT32)(laneAsBytes[5]) << 8) 
+        high = laneAsBytes[4]
+            | ((UINT32)(laneAsBytes[5]) << 8)
             | ((UINT32)(laneAsBytes[6]) << 16)
             | ((UINT32)(laneAsBytes[7]) << 24);
         toBitInterleaving(low, high, lane, lane+1);
@@ -343,7 +343,7 @@ void theta(UINT32 *A)
 
     for(x=0; x<5; x++) {
         for(z=0; z<2; z++) {
-            C[x][z] = 0; 
+            C[x][z] = 0;
             for(y=0; y<5; y++)
                 C[x][z] ^= A[index(x, y, z)];
         }
@@ -383,7 +383,7 @@ void chi(UINT32 *A)
     unsigned int x, y, z;
     UINT32 C[5][2];
 
-    for(y=0; y<5; y++) { 
+    for(y=0; y<5; y++) {
         for(x=0; x<5; x++)
             for(z=0; z<2; z++)
                 C[x][z] = A[index(x, y, z)] ^ ((~A[index(x+1, y, z)]) & A[index(x+2, y, z)]);

--- a/SnP/KeccakF-200/Compact/KeccakF-200-compact.c
+++ b/SnP/KeccakF-200/Compact/KeccakF-200-compact.c
@@ -34,20 +34,20 @@ typedef UINT8 tKeccakLane;
 
 #define ROL8(a, offset) (UINT8)((((UINT8)a) << (offset&7)) ^ (((UINT8)a) >> (8-(offset&7))))
 
-const UINT8 KeccakF_RotationConstants[25] = 
+const UINT8 KeccakF_RotationConstants[25] =
 {
      1,  3,  6, 10, 15, 21, 28, 36, 45, 55,  2, 14, 27, 41, 56,  8, 25, 43, 62, 18, 39, 61, 20, 44
 };
 
-const UINT8 KeccakF_PiLane[25] = 
+const UINT8 KeccakF_PiLane[25] =
 {
-    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1 
+    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1
 };
 
 #if    defined(DIVISION_INSTRUCTION)
 #define MOD5(argValue)    ((argValue) % 5)
 #else
-const UINT8 KeccakF_Mod5[10] = 
+const UINT8 KeccakF_Mod5[10] =
 {
     0, 1, 2, 3, 4, 0, 1, 2, 3, 4
 };

--- a/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv6m-le-armcc.s
+++ b/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv6m-le-armcc.s
@@ -51,11 +51,11 @@ _su	equ 24
 	ldrb		r7, [$ptr, #$g]
 	eors		$result, $result, r7
 	ldrb		r7, [$ptr, #$k]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrb		r7, [$ptr, #$m]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrb		r7, [$ptr, #$s]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	MEND
 
 	MACRO
@@ -239,7 +239,7 @@ KeccakF200_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF200_StateXORLanes
 KeccakF200_StateXORLanes   PROC
@@ -288,7 +288,7 @@ KeccakF200_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes	PROC 
+KeccakF200_StateOverwriteLanes	PROC
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateOverwriteLanes_Exit
 KeccakF200_StateOverwriteLanes_Loop
@@ -327,7 +327,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes	PROC 
+KeccakF200_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	cmp		r1, #0
 	beq		KeccakF200_StateOverwriteWithZeroes_Exit

--- a/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv6m-le-gcc.s
+++ b/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv6m-le-gcc.s
@@ -50,11 +50,11 @@
 	ldrb		r7, [\ptr, #\g]
 	eors		\result, \result, r7
 	ldrb		r7, [\ptr, #\k]
-	eors		\result, \result, r7				
+	eors		\result, \result, r7
 	ldrb		r7, [\ptr, #\m]
-	eors		\result, \result, r7				
+	eors		\result, \result, r7
 	ldrb		r7, [\ptr, #\s]
-	eors		\result, \result, r7				
+	eors		\result, \result, r7
 	.endm
 
 .macro	xorrol 		b, yy, rr
@@ -191,7 +191,7 @@
 @//
 .align 8
 .global   KeccakF200_Initialize
-KeccakF200_Initialize:  
+KeccakF200_Initialize:
 	bx		lr
 
 
@@ -201,7 +201,7 @@ KeccakF200_Initialize:
 @//
 .align 8
 .global   KeccakF200_StateInitialize
-KeccakF200_StateInitialize:  
+KeccakF200_StateInitialize:
 	movs	r1, #0
 	movs	r2, #0
 	movs	r3, #0
@@ -217,7 +217,7 @@ KeccakF200_StateInitialize:
 @//
 .align 8
 .global   KeccakF200_StateComplementBit
-KeccakF200_StateComplementBit:  
+KeccakF200_StateComplementBit:
 	lsrs	r2, r1, #3
 	add		r0, r2
 	ldrb	r2, [r0]
@@ -233,10 +233,10 @@ KeccakF200_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF200_StateXORLanes
-KeccakF200_StateXORLanes:  
+KeccakF200_StateXORLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateXORLanes_Exit
 	push	{r4-r5}
@@ -258,7 +258,7 @@ KeccakF200_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateXORBytesInLane
-KeccakF200_StateXORBytesInLane:  
+KeccakF200_StateXORBytesInLane:
 	push	{r4,lr}
 	ldr		r4, [sp, #8]
 	subs	r4, r4, #1
@@ -282,7 +282,7 @@ KeccakF200_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes: 
+KeccakF200_StateOverwriteLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateOverwriteLanes_Exit
 KeccakF200_StateOverwriteLanes_Loop:
@@ -321,7 +321,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes: 
+KeccakF200_StateOverwriteWithZeroes:
 	movs	r3, #0
 	cmp		r1, #0
 	beq		KeccakF200_StateOverwriteWithZeroes_Exit
@@ -339,7 +339,7 @@ KeccakF200_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractLanes
-KeccakF200_StateExtractLanes:  
+KeccakF200_StateExtractLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateExtractLanes_Exit
 KeccakF200_StateExtractLanes_Loop:
@@ -357,7 +357,7 @@ KeccakF200_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractBytesInLane
-KeccakF200_StateExtractBytesInLane:  
+KeccakF200_StateExtractBytesInLane:
 	add		r0, r0, r1
 	add		r0, r0, r3
 	ldr		r1, [sp]
@@ -423,7 +423,7 @@ KeccakF200_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StatePermute
-KeccakF200_StatePermute:  
+KeccakF200_StatePermute:
 	push	{ r4 - r6, lr }
 	mov		r2, r8
 	mov		r3, r9

--- a/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv7m-le-armcc.s
+++ b/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv7m-le-armcc.s
@@ -151,7 +151,7 @@ KeccakF200_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF200_StateXORLanes
 KeccakF200_StateXORLanes   PROC
@@ -207,7 +207,7 @@ KeccakF200_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes	PROC 
+KeccakF200_StateOverwriteLanes	PROC
 	cbz		r2, KeccakF200_StateOverwriteLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateOverwriteLanes_Loop8
@@ -254,7 +254,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes	PROC 
+KeccakF200_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF200_StateOverwriteWithZeroes_Bytes
@@ -457,7 +457,7 @@ KeccakF200_StatePermute_RoundLoop
 	RhoPi	4, r9, _a, r8, _o		; _ga, _bo	 5 <  3
 	RhoPi	5, r8, _o, r11, _o		; _bo, _mo	 3 < 18
 	RhoPi	7, r11, _o, r11, _i		; _mo, _mi	18 < 17
-	RhoPi	2, r11, _i, r10, _e		; _mi, _ke	17 < 11	
+	RhoPi	2, r11, _i, r10, _e		; _mi, _ke	17 < 11
 	RhoPi	6, r10, _e, r9, _i		; _ke, _gi	11 <  7
 	RhoPi	3, r9, _i, r10, _a		; _gi, _ka	 7 < 10
 	RhoPi	1, r10, _a, r3,      0		; _ka, _be  10 < 1

--- a/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv7m-le-gcc.s
+++ b/SnP/KeccakF-200/OptimizedAsmARM/KeccakF-200-armv7m-le-gcc.s
@@ -109,7 +109,7 @@
 @//
 .align 8
 .global   KeccakF200_Initialize
-KeccakF200_Initialize:  
+KeccakF200_Initialize:
 	bx		lr
 
 
@@ -119,7 +119,7 @@ KeccakF200_Initialize:
 @//
 .align 8
 .global   KeccakF200_StateInitialize
-KeccakF200_StateInitialize:  
+KeccakF200_StateInitialize:
 	movs	r1, #0
 	movs	r2, #0
 	movs	r3, #0
@@ -135,7 +135,7 @@ KeccakF200_StateInitialize:
 @//
 .align 8
 .global   KeccakF200_StateComplementBit
-KeccakF200_StateComplementBit:  
+KeccakF200_StateComplementBit:
 	add		r0, r1, LSR #3
 	ldrb	r2, [r0]
 	and		r1, r1, #7
@@ -149,10 +149,10 @@ KeccakF200_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF200_StateXORLanes
-KeccakF200_StateXORLanes:  
+KeccakF200_StateXORLanes:
 	cbz		r2, KeccakF200_StateXORLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateXORLanes_Loop8
@@ -182,7 +182,7 @@ KeccakF200_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateXORBytesInLane
-KeccakF200_StateXORBytesInLane:  
+KeccakF200_StateXORBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF200_StateXORBytesInLane_Exit
@@ -205,7 +205,7 @@ KeccakF200_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes: 
+KeccakF200_StateOverwriteLanes:
 	cbz		r2, KeccakF200_StateOverwriteLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateOverwriteLanes_Loop8
@@ -252,7 +252,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes: 
+KeccakF200_StateOverwriteWithZeroes:
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF200_StateOverwriteWithZeroes_Bytes
@@ -277,7 +277,7 @@ KeccakF200_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractLanes
-KeccakF200_StateExtractLanes:  
+KeccakF200_StateExtractLanes:
 	cbz		r2, KeccakF200_StateExtractLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateExtractLanes_Loop8
@@ -303,7 +303,7 @@ KeccakF200_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractBytesInLane
-KeccakF200_StateExtractBytesInLane:  
+KeccakF200_StateExtractBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF200_StateExtractBytesInLane_Exit
@@ -377,7 +377,7 @@ KeccakF200_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StatePermute
-KeccakF200_StatePermute:  
+KeccakF200_StatePermute:
 	push		{r4-r12,lr}
 	adr			lr, KeccakF200_StatePermute_RoundConstants
 	@//	Load state into registers
@@ -455,7 +455,7 @@ KeccakF200_StatePermute_RoundLoop:
 	RhoPi	4, r9, _a, r8, _o		@ _ga, _bo	 5 <  3
 	RhoPi	5, r8, _o, r11, _o		@ _bo, _mo	 3 < 18
 	RhoPi	7, r11, _o, r11, _i		@ _mo, _mi	18 < 17
-	RhoPi	2, r11, _i, r10, _e		@ _mi, _ke	17 < 11	
+	RhoPi	2, r11, _i, r10, _e		@ _mi, _ke	17 < 11
 	RhoPi	6, r10, _e, r9, _i		@ _ke, _gi	11 <  7
 	RhoPi	3, r9, _i, r10, _a		@ _gi, _ka	 7 < 10
 	RhoPi	1, r10, _a, r3,      0		@ _ka, _be  10 < 1

--- a/SnP/KeccakF-200/OptimizedAsmAVR8/KeccakF-200-avr8-fast.s
+++ b/SnP/KeccakF-200/OptimizedAsmAVR8/KeccakF-200-avr8-fast.s
@@ -615,7 +615,7 @@ KeccakF200_StatePermute_Done:
     ret
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakF-200/Reference/KeccakF-200-reference.c
+++ b/SnP/KeccakF-200/Reference/KeccakF-200-reference.c
@@ -126,7 +126,7 @@ void KeccakF200_StateComplementBit(void *state, unsigned int position)
     if (position < 200) {
         unsigned int bytePosition = position/8;
         unsigned int bitPosition = position%8;
-        
+
         ((unsigned char *)state)[bytePosition] ^= (UINT8)1 << bitPosition;
     }
 }
@@ -208,8 +208,8 @@ void theta(tKeccakLane *A)
     tKeccakLane C[5], D[5];
 
     for(x=0; x<5; x++) {
-        C[x] = 0; 
-        for(y=0; y<5; y++) 
+        C[x] = 0;
+        for(y=0; y<5; y++)
             C[x] ^= A[index(x, y)];
     }
     for(x=0; x<5; x++)
@@ -243,7 +243,7 @@ void chi(tKeccakLane *A)
     unsigned int x, y;
     tKeccakLane C[5];
 
-    for(y=0; y<5; y++) { 
+    for(y=0; y<5; y++) {
         for(x=0; x<5; x++)
             C[x] = A[index(x, y)] ^ ((~A[index(x+1, y)]) & A[index(x+2, y)]);
         for(x=0; x<5; x++)

--- a/SnP/KeccakF-400/OptimizedAsmARM/KeccakF-400-armv6m-le-armcc.s
+++ b/SnP/KeccakF-400/OptimizedAsmARM/KeccakF-400-armv6m-le-armcc.s
@@ -51,11 +51,11 @@ _su		equ 24*2
 	ldrh		r7, [$ptr, #$g]
 	eors		$result, $result, r7
 	ldrh		r7, [$ptr, #$k]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrh		r7, [$ptr, #$m]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrh		r7, [$ptr, #$s]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	MEND
 
 	MACRO
@@ -247,7 +247,7 @@ KeccakF400_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF400_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF400_StateXORLanes
 KeccakF400_StateXORLanes   PROC
@@ -310,7 +310,7 @@ KeccakF400_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteLanes
-KeccakF400_StateOverwriteLanes	PROC 
+KeccakF400_StateOverwriteLanes	PROC
 	subs	r2, r2, #1
 	bcc		KeccakF400_StateOverwriteLanes_Exit
 	lsls	r2, r2, #1
@@ -361,7 +361,7 @@ KeccakF400_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteWithZeroes
-KeccakF400_StateOverwriteWithZeroes	PROC 
+KeccakF400_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	cmp		r1, #0
 	beq		KeccakF400_StateOverwriteWithZeroes_Exit

--- a/SnP/KeccakF-400/OptimizedAsmARM/KeccakF-400-armv7m-le-armcc.s
+++ b/SnP/KeccakF-400/OptimizedAsmARM/KeccakF-400-armv7m-le-armcc.s
@@ -53,10 +53,10 @@ _su		equ 24*2
 	ldrh		r6, [$ptr, #$g]
 	eor			$result, $result, $rs
 	ldrh		$rs, [$ptr, #$k]
-	eor			$result, $result, r6				
+	eor			$result, $result, r6
 	ldrh		r6, [$ptr, #$m]
 	eor			$result, $result, $rs
-	eor			$result, $result, r6				
+	eor			$result, $result, r6
 	MEND
 
 	MACRO
@@ -66,10 +66,10 @@ _su		equ 24*2
 	ldr			r6, [$ptr, #$g]
 	eor			$resultL, $resultL, $rsL
 	ldr			$rsL, [$ptr, #$k]
-	eor			$resultL, $resultL, r6				
+	eor			$resultL, $resultL, r6
 	ldr			r6, [$ptr, #$m]
 	eor			$resultL, $resultL, $rsL
-	eor			$resultL, $resultL, r6				
+	eor			$resultL, $resultL, r6
 	lsr			$resultH, $resultL, #16
 	uxth 		$resultL, $resultL
 	MEND
@@ -256,7 +256,7 @@ KeccakF400_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF400_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF400_StateXORLanes
 KeccakF400_StateXORLanes   PROC
@@ -310,7 +310,7 @@ KeccakF400_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteLanes
-KeccakF400_StateOverwriteLanes	PROC 
+KeccakF400_StateOverwriteLanes	PROC
 	cbz		r2, KeccakF400_StateOverwriteLanes_Exit
 KeccakF400_StateOverwriteLanes_Loop
 	ldrh	r3, [r1], #2
@@ -347,7 +347,7 @@ KeccakF400_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteWithZeroes
-KeccakF400_StateOverwriteWithZeroes	PROC 
+KeccakF400_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF400_StateOverwriteWithZeroes_Bytes
@@ -464,11 +464,11 @@ KeccakF400_StatePermute   PROC
 	sub			sp, sp, #2*25+6
 	adr			r8, KeccakF400_StatePermute_RoundConstants
 KeccakF400_StatePermuteIntern
-    ldrh		r9, [r0, #_sa] 
-    ldrh		r10, [r0, #_se] 
-    ldrh		r11, [r0, #_si] 
-    ldrh		lr, [r0, #_su] 
-    ldrh		r12, [r0, #_so] 
+    ldrh		r9, [r0, #_sa]
+    ldrh		r10, [r0, #_se]
+    ldrh		r11, [r0, #_si]
+    ldrh		lr, [r0, #_su]
+    ldrh		r12, [r0, #_so]
 	mov			r5, lr
     xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakF400_StatePermute_RoundLoop

--- a/SnP/KeccakF-400/OptimizedAsmARM/KeccakF-400-armv7m-le-gcc.s
+++ b/SnP/KeccakF-400/OptimizedAsmARM/KeccakF-400-armv7m-le-gcc.s
@@ -52,10 +52,10 @@
 	ldrh		r6, [\ptr, #\g]
 	eor			\result, \result, \rs
 	ldrh		\rs, [\ptr, #\k]
-	eor			\result, \result, r6				
+	eor			\result, \result, r6
 	ldrh		r6, [\ptr, #\m]
 	eor			\result, \result, \rs
-	eor			\result, \result, r6				
+	eor			\result, \result, r6
 	.endm
 
 .macro	xor5D		resultL,resultH,ptr,b,g,k,m,rsL,rsH
@@ -64,10 +64,10 @@
 	ldr			r6, [\ptr, #\g]
 	eor			\resultL, \resultL, \rsL
 	ldr			\rsL, [\ptr, #\k]
-	eor			\resultL, \resultL, r6				
+	eor			\resultL, \resultL, r6
 	ldr			r6, [\ptr, #\m]
 	eor			\resultL, \resultL, \rsL
-	eor			\resultL, \resultL, r6				
+	eor			\resultL, \resultL, r6
 	lsr			\resultH, \resultL, #16
 	uxth 		\resultL, \resultL
 	.endm
@@ -207,7 +207,7 @@
 @//
 .align 8
 .global   KeccakF400_Initialize
-KeccakF400_Initialize:  
+KeccakF400_Initialize:
 	bx		lr
 
 
@@ -217,7 +217,7 @@ KeccakF400_Initialize:
 @//
 .align 8
 .global   KeccakF400_StateInitialize
-KeccakF400_StateInitialize:  
+KeccakF400_StateInitialize:
 	movs	r1, #0
 	movs	r2, #0
 	movs	r3, #0
@@ -235,7 +235,7 @@ KeccakF400_StateInitialize:
 @//
 .align 8
 .global   KeccakF400_StateComplementBit
-KeccakF400_StateComplementBit:  
+KeccakF400_StateComplementBit:
 	add		r0, r1, LSR #3
 	ldrb	r2, [r0]
 	and		r1, r1, #7
@@ -249,10 +249,10 @@ KeccakF400_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF400_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF400_StateXORLanes
-KeccakF400_StateXORLanes:  
+KeccakF400_StateXORLanes:
 	cbz		r2, KeccakF400_StateXORLanes_Exit
 	subs	r3, r2, #2
 	bcc		KeccakF400_StateXORLanes_1Lane
@@ -280,7 +280,7 @@ KeccakF400_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF400_StateXORBytesInLane
-KeccakF400_StateXORBytesInLane:  
+KeccakF400_StateXORBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF400_StateXORBytesInLane_Exit
@@ -303,7 +303,7 @@ KeccakF400_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF400_StateOverwriteLanes
-KeccakF400_StateOverwriteLanes: 
+KeccakF400_StateOverwriteLanes:
 	cbz		r2, KeccakF400_StateOverwriteLanes_Exit
 KeccakF400_StateOverwriteLanes_Loop:
 	ldrh	r3, [r1], #2
@@ -340,7 +340,7 @@ KeccakF400_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF400_StateOverwriteWithZeroes
-KeccakF400_StateOverwriteWithZeroes: 
+KeccakF400_StateOverwriteWithZeroes:
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF400_StateOverwriteWithZeroes_Bytes
@@ -365,7 +365,7 @@ KeccakF400_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF400_StateExtractLanes
-KeccakF400_StateExtractLanes:  
+KeccakF400_StateExtractLanes:
 	cbz		r2, KeccakF400_StateExtractLanes_Exit
 	subs	r3, r2, #2
 	bcc		KeccakF400_StateExtractLanes_1Lane
@@ -389,7 +389,7 @@ KeccakF400_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF400_StateExtractBytesInLane
-KeccakF400_StateExtractBytesInLane:  
+KeccakF400_StateExtractBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF400_StateExtractBytesInLane_Exit
@@ -452,16 +452,16 @@ KeccakF400_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF400_StatePermute
-KeccakF400_StatePermute:  
+KeccakF400_StatePermute:
 	push		{r4-r12,lr}
 	sub			sp, sp, #2*25+6
 	adr			r8, KeccakF400_StatePermute_RoundConstants
 KeccakF400_StatePermuteIntern:
-    ldrh		r9, [r0, #_sa] 
-    ldrh		r10, [r0, #_se] 
-    ldrh		r11, [r0, #_si] 
-    ldrh		lr, [r0, #_su] 
-    ldrh		r12, [r0, #_so] 
+    ldrh		r9, [r0, #_sa]
+    ldrh		r10, [r0, #_se]
+    ldrh		r11, [r0, #_si]
+    ldrh		lr, [r0, #_su]
+    ldrh		r12, [r0, #_so]
 	mov			r5, lr
     xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakF400_StatePermute_RoundLoop:

--- a/SnP/KeccakF-400/OptimizedAsmAVR8/KeccakF-400-avr8-fast.s
+++ b/SnP/KeccakF-400/OptimizedAsmAVR8/KeccakF-400-avr8-fast.s
@@ -680,7 +680,7 @@ rotate16_1bit_right:
     #undef  pRound
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakF-400/Reference/KeccakF-400-reference.c
+++ b/SnP/KeccakF-400/Reference/KeccakF-400-reference.c
@@ -127,7 +127,7 @@ void KeccakF400_StateComplementBit(void *state, unsigned int position)
     if (position < 400) {
         unsigned int bytePosition = position/8;
         unsigned int bitPosition = position%8;
-        
+
         ((unsigned char *)state)[bytePosition] ^= (UINT8)1 << bitPosition;
     }
 }
@@ -218,8 +218,8 @@ void theta(tKeccakLane *A)
     tKeccakLane C[5], D[5];
 
     for(x=0; x<5; x++) {
-        C[x] = 0; 
-        for(y=0; y<5; y++) 
+        C[x] = 0;
+        for(y=0; y<5; y++)
             C[x] ^= A[index(x, y)];
     }
     for(x=0; x<5; x++)
@@ -253,7 +253,7 @@ void chi(tKeccakLane *A)
     unsigned int x, y;
     tKeccakLane C[5];
 
-    for(y=0; y<5; y++) { 
+    for(y=0; y<5; y++) {
         for(x=0; x<5; x++)
             C[x] = A[index(x, y)] ^ ((~A[index(x+1, y)]) & A[index(x+2, y)]);
         for(x=0; x<5; x++)

--- a/SnP/KeccakF-800/Compact/KeccakF-800-compact.c
+++ b/SnP/KeccakF-800/Compact/KeccakF-800-compact.c
@@ -47,20 +47,20 @@ typedef UINT32 tKeccakLane;
 
 #define    cKeccakNumberOfRounds    22
 
-const UINT8 KeccakF_RotationConstants[25] = 
+const UINT8 KeccakF_RotationConstants[25] =
 {
      1,  3,  6, 10, 15, 21, 28, 36, 45, 55,  2, 14, 27, 41, 56,  8, 25, 43, 62, 18, 39, 61, 20, 44
 };
 
-const UINT8 KeccakF_PiLane[25] = 
+const UINT8 KeccakF_PiLane[25] =
 {
-    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1 
+    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1
 };
 
 #if    defined(DIVISION_INSTRUCTION)
 #define MOD5(argValue)    ((argValue) % 5)
 #else
-const UINT8 KeccakF_Mod5[10] = 
+const UINT8 KeccakF_Mod5[10] =
 {
     0, 1, 2, 3, 4, 0, 1, 2, 3, 4
 };
@@ -198,7 +198,7 @@ void KeccakF800_StatePermute(void *argState)
 	nr = 22;
 	for ( y = (tSmallUInt)(cKeccakNumberOfRounds - 22); y != 0; --y )
 	{
-        for( x = 1; x < 128; x <<= 1 ) 
+        for( x = 1; x < 128; x <<= 1 )
         {
             if ((LFSRstate & 0x80) != 0)
                 // Primitive polynomial over GF(2): x^8+x^6+x^5+x^4+1
@@ -256,7 +256,7 @@ void KeccakF800_StatePermute(void *argState)
 
         //    Iota
         temp = 0;
-        for( x = 1; x < 128; x <<= 1 ) 
+        for( x = 1; x < 128; x <<= 1 )
         {
             if ( x <= (sizeof(tKeccakLane)*8) )
                 temp ^= (tKeccakLane)(LFSRstate & 1) << (x - 1);

--- a/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv6m-le-armcc.s
+++ b/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv6m-le-armcc.s
@@ -53,11 +53,11 @@ _su		equ 24*4
 	ldr			r6, [$ptr, #$g]
 	eors		$result, $result, r6
 	ldr			r6, [$ptr, #$k]
-	eors		$result, $result, r6				
+	eors		$result, $result, r6
 	ldr			r6, [$ptr, #$m]
-	eors		$result, $result, r6				
+	eors		$result, $result, r6
 	ldr			r6, [$ptr, #$s]
-	eors		$result, $result, r6				
+	eors		$result, $result, r6
 	MEND
 
 	MACRO
@@ -249,7 +249,7 @@ KeccakF800_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF800_StateXORLanes
 KeccakF800_StateXORLanes   PROC
@@ -325,7 +325,7 @@ KeccakF800_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes	PROC 
+KeccakF800_StateOverwriteLanes	PROC
 	subs	r2, r2, #1
 	bcc		KeccakF800_StateOverwriteLanes_Exit
 	lsls	r2, r2, #2
@@ -376,7 +376,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes	PROC 
+KeccakF800_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -567,7 +567,7 @@ KeccakF800_StatePermute_RoundConstants
 	dcd			0x0000800a
 	dcd			0x8000000a
 	dcd			0x80008081
-	dcd			0x00008080 
+	dcd			0x00008080
 	dcd			0xFF			;//terminator
 
 ;//----------------------------------------------------------------------------
@@ -605,7 +605,7 @@ KeccakP800_StatePermute_Done
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -680,7 +680,7 @@ KeccakF800_SnP_FBWL_Absorb_TrailingBits
 KeccakF800_SnP_FBWL_Absorb_Exit
 	mov		r0, r4						; return processed
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -742,7 +742,7 @@ KeccakF800_SnP_FBWL_Squeeze_CheckLoop
 KeccakF800_SnP_FBWL_Squeeze_Exit
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -766,7 +766,7 @@ KeccakF800_SnP_FBWL_Squeeze_Unaligned_LoopLane
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -857,7 +857,7 @@ KeccakF800_SnP_FBWL_Wrap_TrailingBits
 KeccakF800_SnP_FBWL_Wrap_Exit
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -868,7 +868,7 @@ KeccakF800_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -959,7 +959,7 @@ KeccakF800_SnP_FBWL_Unwrap_TrailingBits
 KeccakF800_SnP_FBWL_Unwrap_Exit
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4

--- a/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv6m-le-gcc.s
+++ b/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv6m-le-gcc.s
@@ -52,11 +52,11 @@
 	ldr			r6, [\ptr, #\g]
 	eors		\result, \result, r6
 	ldr			r6, [\ptr, #\k]
-	eors		\result, \result, r6				
+	eors		\result, \result, r6
 	ldr			r6, [\ptr, #\m]
-	eors		\result, \result, r6				
+	eors		\result, \result, r6
 	ldr			r6, [\ptr, #\s]
-	eors		\result, \result, r6				
+	eors		\result, \result, r6
 	.endm
 
 .macro	xorrol 		b, yy, rr
@@ -195,7 +195,7 @@
 @//
 .align 8
 .global   KeccakF800_Initialize
-KeccakF800_Initialize:  
+KeccakF800_Initialize:
 	bx		lr
 
 
@@ -205,7 +205,7 @@ KeccakF800_Initialize:
 @//
 .align 8
 .global   KeccakF800_StateInitialize
-KeccakF800_StateInitialize:  
+KeccakF800_StateInitialize:
 	push	{r4 - r5}
 	movs	r1, #0
 	movs	r2, #0
@@ -227,7 +227,7 @@ KeccakF800_StateInitialize:
 @//
 .align 8
 .global   KeccakF800_StateComplementBit
-KeccakF800_StateComplementBit:  
+KeccakF800_StateComplementBit:
 	lsrs	r2, r1, #3
 	add		r0, r2
 	ldrb	r2, [r0]
@@ -243,10 +243,10 @@ KeccakF800_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF800_StateXORLanes
-KeccakF800_StateXORLanes:  
+KeccakF800_StateXORLanes:
 	subs	r3, r2, #1
 	bcc		KeccakF800_StateXORLanes_Exit
 	push	{r4,r5}
@@ -294,7 +294,7 @@ KeccakF800_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF800_StateXORBytesInLane
-KeccakF800_StateXORBytesInLane:  
+KeccakF800_StateXORBytesInLane:
 	push	{r4,lr}
 	ldr		r4, [sp, #8]
 	subs	r4, r4, #1
@@ -319,7 +319,7 @@ KeccakF800_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes: 
+KeccakF800_StateOverwriteLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF800_StateOverwriteLanes_Exit
 	lsls	r2, r2, #2
@@ -370,7 +370,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes: 
+KeccakF800_StateOverwriteWithZeroes:
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -396,7 +396,7 @@ KeccakF800_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF800_StateExtractLanes
-KeccakF800_StateExtractLanes:  
+KeccakF800_StateExtractLanes:
 	subs	r3, r2, #1
 	bcc		KeccakF800_StateExtractLanes_Exit
 	lsls	r3, r1, #30
@@ -438,7 +438,7 @@ KeccakF800_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF800_StateExtractBytesInLane
-KeccakF800_StateExtractBytesInLane:  
+KeccakF800_StateExtractBytesInLane:
 	push	{r4,lr}
 	ldr		r4, [sp, #8]
 	subs	r4, r4, #1
@@ -533,7 +533,7 @@ KeccakF800_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF800_StatePermute
-KeccakF800_StatePermute:  
+KeccakF800_StatePermute:
 	adr		r1, KeccakF800_StatePermute_RoundConstants
 	b		KeccakP800_StatePermute
 
@@ -561,7 +561,7 @@ KeccakF800_StatePermute_RoundConstants:
 		.long 			0x0000800a
 		.long 			0x8000000a
 		.long 			0x80008081
-		.long 			0x00008080 
+		.long 			0x00008080
 		.long 			0xFF			@//terminator
 
 @//----------------------------------------------------------------------------
@@ -569,7 +569,7 @@ KeccakF800_StatePermute_RoundConstants:
 @// void KeccakP800_StatePermute( void *state, void *rc )
 @//
 .align 8
-KeccakP800_StatePermute:  
+KeccakP800_StatePermute:
 	push	{ r4 - r6, lr }
 	mov		r2, r8
 	mov		r3, r9
@@ -599,7 +599,7 @@ KeccakP800_StatePermute_Done:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+@ size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 @										size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -674,7 +674,7 @@ KeccakF800_SnP_FBWL_Absorb_TrailingBits:
 KeccakF800_SnP_FBWL_Absorb_Exit:
 	mov		r0, r4						@ return processed
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -736,7 +736,7 @@ KeccakF800_SnP_FBWL_Squeeze_CheckLoop:
 KeccakF800_SnP_FBWL_Squeeze_Exit:
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -760,7 +760,7 @@ KeccakF800_SnP_FBWL_Squeeze_Unaligned_LoopLane:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -851,7 +851,7 @@ KeccakF800_SnP_FBWL_Wrap_TrailingBits:
 KeccakF800_SnP_FBWL_Wrap_Exit:
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -862,7 +862,7 @@ KeccakF800_SnP_FBWL_Wrap_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 @
 .align 8
@@ -953,7 +953,7 @@ KeccakF800_SnP_FBWL_Unwrap_TrailingBits:
 KeccakF800_SnP_FBWL_Unwrap_Exit:
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4

--- a/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7a-le-armcc.s
+++ b/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7a-le-armcc.s
@@ -253,7 +253,7 @@ KeccakF800_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF800_StateXORLanes
 KeccakF800_StateXORLanes   PROC
@@ -319,7 +319,7 @@ KeccakF800_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes	PROC 
+KeccakF800_StateOverwriteLanes	PROC
 	subs	r2, r2, #8
 	bcc		KeccakF800_StateOverwriteLanes_LessThan8Lanes
 	push	{ r4 - r5 }
@@ -383,7 +383,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes	PROC 
+KeccakF800_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -554,7 +554,7 @@ KeccakF800_StatePermute_RoundConstantsWithTerminator
 	dcd			0x0000800a
 	dcd			0x8000000a
 	dcd			0x80008081
-	dcd			0x00008080 
+	dcd			0x00008080
 	dcd			0			;//terminator
 
 ;//----------------------------------------------------------------------------
@@ -574,10 +574,10 @@ KeccakF800_StatePermute   PROC
 	mov			r6, r12
 	eor			r7, r7, r12
 	ldr			r12, [r0, #_ku]
-	eor			r7, r7, r1				
+	eor			r7, r7, r1
 	ldr			r1, [r0, #_mu]
 	eor			r7, r7, r12
-	eor			r7, r7, r1				
+	eor			r7, r7, r1
 KeccakF800_StatePermute_RoundLoop
 	KeccakRound	sp, r0
 	KeccakRound	r0, sp
@@ -590,7 +590,7 @@ KeccakF800_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -694,7 +694,7 @@ KeccakF800_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -758,7 +758,7 @@ KeccakF800_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN

--- a/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7a-le-gcc.s
+++ b/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7a-le-gcc.s
@@ -202,7 +202,7 @@
 @//
 .align 8
 .global   KeccakF800_Initialize
-KeccakF800_Initialize:  
+KeccakF800_Initialize:
 	bx		lr
 
 
@@ -212,7 +212,7 @@ KeccakF800_Initialize:
 @//
 .align 8
 .global   KeccakF800_StateInitialize
-KeccakF800_StateInitialize:  
+KeccakF800_StateInitialize:
 	push	{r4 - r5}
 	movs	r1, #0
 	movs	r2, #0
@@ -234,7 +234,7 @@ KeccakF800_StateInitialize:
 @//
 .align 8
 .global   KeccakF800_StateComplementBit
-KeccakF800_StateComplementBit:  
+KeccakF800_StateComplementBit:
 	lsrs	r2, r1, #5
 	add		r0, r2, LSL #2
 	ldr		r2, [r0]
@@ -249,10 +249,10 @@ KeccakF800_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF800_StateXORLanes
-KeccakF800_StateXORLanes:  
+KeccakF800_StateXORLanes:
 	subs	r2, r2, #4
 	bcc		KeccakF800_StateXORLanes_LessThan4Lanes
 	push	{ r4 - r5 }
@@ -292,7 +292,7 @@ KeccakF800_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF800_StateXORBytesInLane
-KeccakF800_StateXORBytesInLane:  
+KeccakF800_StateXORBytesInLane:
 	adds	r0, r0, r3
 	ldr		r3, [sp]
 	cmp		r3, #0
@@ -315,7 +315,7 @@ KeccakF800_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes: 
+KeccakF800_StateOverwriteLanes:
 	subs	r2, r2, #8
 	bcc		KeccakF800_StateOverwriteLanes_LessThan8Lanes
 	push	{ r4 - r5 }
@@ -379,7 +379,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes: 
+KeccakF800_StateOverwriteWithZeroes:
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -404,7 +404,7 @@ KeccakF800_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF800_StateExtractLanes
-KeccakF800_StateExtractLanes:  
+KeccakF800_StateExtractLanes:
 	subs	r2, r2, #8
 	bcc		KeccakF800_StateExtractLanes_LessThan8Lanes
 	push	{ r4 - r5 }
@@ -447,7 +447,7 @@ KeccakF800_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF800_StateExtractBytesInLane
-KeccakF800_StateExtractBytesInLane:  
+KeccakF800_StateExtractBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF800_StateExtractBytesInLane_Exit
@@ -550,7 +550,7 @@ KeccakF800_StatePermute_RoundConstantsWithTerminator:
 		.long 			0x0000800a
 		.long 			0x8000000a
 		.long 			0x80008081
-		.long 			0x00008080 
+		.long 			0x00008080
 		.long 			0			@//terminator
 
 @//----------------------------------------------------------------------------
@@ -559,7 +559,7 @@ KeccakF800_StatePermute_RoundConstantsWithTerminator:
 @//
 .align 8
 .global   KeccakF800_StatePermute
-KeccakF800_StatePermute:  
+KeccakF800_StatePermute:
 	push		{r4-r12,lr}
 	adr			lr, KeccakF800_StatePermute_RoundConstantsWithTerminator
 	add			r2, r0, #_sa
@@ -570,10 +570,10 @@ KeccakF800_StatePermute:
 	mov			r6, r12
 	eor			r7, r7, r12
 	ldr			r12, [r0, #_ku]
-	eor			r7, r7, r1				
+	eor			r7, r7, r1
 	ldr			r1, [r0, #_mu]
 	eor			r7, r7, r12
-	eor			r7, r7, r1				
+	eor			r7, r7, r1
 KeccakF800_StatePermute_RoundLoop:
 	KeccakRound	sp, r0
 	KeccakRound	r0, sp
@@ -586,7 +586,7 @@ KeccakF800_StatePermute_RoundLoop:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+@ size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 @										size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -690,7 +690,7 @@ KeccakF800_SnP_FBWL_Squeeze_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -754,7 +754,7 @@ KeccakF800_SnP_FBWL_Wrap_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 @
 .align 8

--- a/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7m-le-armcc.s
+++ b/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7m-le-armcc.s
@@ -160,10 +160,10 @@ _su		equ 24*4
 		ldr			r6, [$ptr, #$g]
 		eor			$result, $result, $rs
 		ldr			$rs, [$ptr, #$k]
-		eor			$result, $result, r6				
+		eor			$result, $result, r6
 		ldr			r6, [$ptr, #$m]
 		eor			$result, $result, $rs
-		eor			$result, $result, r6				
+		eor			$result, $result, r6
 		MEND
 
 		MACRO
@@ -246,7 +246,7 @@ KeccakF800_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 		ALIGN
 		EXPORT  KeccakF800_StateXORLanes
 KeccakF800_StateXORLanes   PROC
@@ -311,7 +311,7 @@ KeccakF800_StateXORBytesInLane_Exit
 ;//
 		ALIGN
 		EXPORT  KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes	PROC 
+KeccakF800_StateOverwriteLanes	PROC
 		subs	r2, r2, #8
 		bcc		KeccakF800_StateOverwriteLanes_LessThan8Lanes
 		push	{ r4 - r5 }
@@ -375,7 +375,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit
 ;//
 		ALIGN
 		EXPORT  KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes	PROC 
+KeccakF800_StateOverwriteWithZeroes	PROC
 		movs	r3, #0
 		lsrs	r2, r1, #2
 		beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -546,7 +546,7 @@ KeccakF800_StatePermute_RoundConstantsWithTerminator
 		dcd			0x0000800a
 		dcd			0x8000000a
 		dcd			0x80008081
-		dcd			0x00008080 
+		dcd			0x00008080
 		dcd			0			;//terminator
 
 ;//----------------------------------------------------------------------------
@@ -559,11 +559,11 @@ KeccakF800_StatePermute   PROC
 		push		{r4-r12,lr}
 		sub			sp, sp, #4*25
 		adr			r8, KeccakF800_StatePermute_RoundConstantsWithTerminator
-	    ldr			r9, [r0, #_sa] 
-	    ldr			r10, [r0, #_se] 
-	    ldr			r11, [r0, #_si] 
-	    ldr			lr, [r0, #_su] 
-	    ldr			r12, [r0, #_so] 
+	    ldr			r9, [r0, #_sa]
+	    ldr			r10, [r0, #_se]
+	    ldr			r11, [r0, #_si]
+	    ldr			lr, [r0, #_su]
+	    ldr			r12, [r0, #_so]
 		mov			r5, lr
 	    xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakP800_StatePermute_RoundLoop
@@ -577,7 +577,7 @@ KeccakP800_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -681,7 +681,7 @@ KeccakF800_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -745,7 +745,7 @@ KeccakF800_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN

--- a/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7m-le-gcc.s
+++ b/SnP/KeccakF-800/OptimizedAsmARM/KeccakF-800-armv7m-le-gcc.s
@@ -15,7 +15,7 @@
 
 @ WARNING: These functions work only on little endian CPU with@ ARMv7m architecture (Cortex-M3, ...).
 
-	
+
 		.thumb
 .text
 
@@ -158,10 +158,10 @@
 		ldr			r6, [\ptr, #\g]
 		eor			\result, \result, \rs
 		ldr			\rs, [\ptr, #\k]
-		eor			\result, \result, r6				
+		eor			\result, \result, r6
 		ldr			r6, [\ptr, #\m]
 		eor			\result, \result, \rs
-		eor			\result, \result, r6				
+		eor			\result, \result, r6
 		.endm
 
 .macro		xorrol 		b, yy, rr
@@ -194,9 +194,9 @@
 @//
 	.align 8
 .global   KeccakF800_Initialize
-KeccakF800_Initialize:  
+KeccakF800_Initialize:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -204,7 +204,7 @@ KeccakF800_Initialize:
 @//
 	.align 8
 .global   KeccakF800_StateInitialize
-KeccakF800_StateInitialize:  
+KeccakF800_StateInitialize:
 		push	{r4 - r5}
 		movs	r1, #0
 		movs	r2, #0
@@ -218,7 +218,7 @@ KeccakF800_StateInitialize:
 		stmia	r0!, { r1 - r5 }
 		pop		{r4 - r5}
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -226,7 +226,7 @@ KeccakF800_StateInitialize:
 @//
 	.align 8
 .global   KeccakF800_StateComplementBit
-KeccakF800_StateComplementBit:  
+KeccakF800_StateComplementBit:
 		lsrs	r2, r1, #5
 		add		r0, r2, LSL #2
 		ldr		r2, [r0]
@@ -236,15 +236,15 @@ KeccakF800_StateComplementBit:
 		eors	r3, r3, r2
 		str		r3, [r0]
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 	.align 8
 .global   KeccakF800_StateXORLanes
-KeccakF800_StateXORLanes:  
+KeccakF800_StateXORLanes:
 		subs	r2, r2, #4
 		bcc		KeccakF800_StateXORLanes_LessThan4Lanes
 		push	{ r4 - r5 }
@@ -276,7 +276,7 @@ KeccakF800_StateXORLanes_LoopLane:
 		bne		KeccakF800_StateXORLanes_LoopLane
 KeccakF800_StateXORLanes_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -284,7 +284,7 @@ KeccakF800_StateXORLanes_Exit:
 @//
 	.align 8
 .global   KeccakF800_StateXORBytesInLane
-KeccakF800_StateXORBytesInLane:  
+KeccakF800_StateXORBytesInLane:
 		adds	r0, r0, r3
 		ldr		r3, [sp]
 		cbz		r3, KeccakF800_StateXORBytesInLane_Exit
@@ -298,7 +298,7 @@ KeccakF800_StateXORBytesInLane_Loop:
 		bne		KeccakF800_StateXORBytesInLane_Loop
 KeccakF800_StateXORBytesInLane_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -306,7 +306,7 @@ KeccakF800_StateXORBytesInLane_Exit:
 @//
 	.align 8
 .global   KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes: 
+KeccakF800_StateOverwriteLanes:
 		subs	r2, r2, #8
 		bcc		KeccakF800_StateOverwriteLanes_LessThan8Lanes
 		push	{ r4 - r5 }
@@ -341,7 +341,7 @@ KeccakF800_StateOverwriteLanes_LessThan2Lanes:
 		str		r3, [r0]
 KeccakF800_StateOverwriteLanes_Exit:
 		bx		lr
-	
+
 
 
 @//----------------------------------------------------------------------------
@@ -362,7 +362,7 @@ KeccakF800_StateOverwriteBytesInLane_Loop:
 		bne		KeccakF800_StateOverwriteBytesInLane_Loop
 KeccakF800_StateOverwriteBytesInLane_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -370,7 +370,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit:
 @//
 	.align 8
 .global   KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes: 
+KeccakF800_StateOverwriteWithZeroes:
 		movs	r3, #0
 		lsrs	r2, r1, #2
 		beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -387,7 +387,7 @@ KeccakF800_StateOverwriteWithZeroes_LoopBytes:
 		bne		KeccakF800_StateOverwriteWithZeroes_LoopBytes
 KeccakF800_StateOverwriteWithZeroes_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -395,7 +395,7 @@ KeccakF800_StateOverwriteWithZeroes_Exit:
 @//
 	.align 8
 .global   KeccakF800_StateExtractLanes
-KeccakF800_StateExtractLanes:  
+KeccakF800_StateExtractLanes:
 		subs	r2, r2, #8
 		bcc		KeccakF800_StateExtractLanes_LessThan8Lanes
 		push	{ r4 - r5 }
@@ -430,7 +430,7 @@ KeccakF800_StateExtractLanes_LessThan2Lanes:
 		str		r3, [r1], #4
 KeccakF800_StateExtractLanes_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -438,7 +438,7 @@ KeccakF800_StateExtractLanes_Exit:
 @//
 	.align 8
 .global   KeccakF800_StateExtractBytesInLane
-KeccakF800_StateExtractBytesInLane:  
+KeccakF800_StateExtractBytesInLane:
 		ldr		r12, [sp]
 		cmp		r12, #0
 		beq		KeccakF800_StateExtractBytesInLane_Exit
@@ -451,7 +451,7 @@ KeccakF800_StateExtractBytesInLane_Loop:
 		bne		KeccakF800_StateExtractBytesInLane_Loop
 KeccakF800_StateExtractBytesInLane_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -493,7 +493,7 @@ KeccakF800_StateExtractAndXORLanes_LoopLane:
 		bne		KeccakF800_StateExtractAndXORLanes_LoopLane
 KeccakF800_StateExtractAndXORLanes_Exit:
 		bx		lr
-	
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -516,7 +516,7 @@ KeccakF800_StateExtractAndXORBytesInLane_Loop:
 		bne		KeccakF800_StateExtractAndXORBytesInLane_Loop
 KeccakF800_StateExtractAndXORBytesInLane_Exit:
 		bx		lr
-	
+
 
 	.align 8
 KeccakF800_StatePermute_RoundConstantsWithTerminator:
@@ -541,7 +541,7 @@ KeccakF800_StatePermute_RoundConstantsWithTerminator:
 		.long 			0x0000800a
 		.long 			0x8000000a
 		.long 			0x80008081
-		.long 			0x00008080 
+		.long 			0x00008080
 		.long 			0			@//terminator
 
 @//----------------------------------------------------------------------------
@@ -550,15 +550,15 @@ KeccakF800_StatePermute_RoundConstantsWithTerminator:
 @//
 	.align 8
 .global   KeccakF800_StatePermute
-KeccakF800_StatePermute:  
+KeccakF800_StatePermute:
 		push		{r4-r12,lr}
 		sub			sp, sp, #4*25
 		adr			r8, KeccakF800_StatePermute_RoundConstantsWithTerminator
-	    ldr			r9, [r0, #_sa] 
-	    ldr			r10, [r0, #_se] 
-	    ldr			r11, [r0, #_si] 
-	    ldr			lr, [r0, #_su] 
-	    ldr			r12, [r0, #_so] 
+	    ldr			r9, [r0, #_sa]
+	    ldr			r10, [r0, #_se]
+	    ldr			r11, [r0, #_si]
+	    ldr			lr, [r0, #_su]
+	    ldr			r12, [r0, #_so]
 		mov			r5, lr
 	    xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakP800_StatePermute_RoundLoop:
@@ -568,11 +568,11 @@ KeccakP800_StatePermute_RoundLoop:
 		bne			KeccakP800_StatePermute_RoundLoop
 		add			sp,sp,#4*25
 		pop			{r4-r12,pc}
-	
+
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+@ size_t KeccakF800_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 @										size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -676,7 +676,7 @@ KeccakF800_SnP_FBWL_Squeeze_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF800_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -740,7 +740,7 @@ KeccakF800_SnP_FBWL_Wrap_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakF800_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 @
 .align 8

--- a/SnP/KeccakF-800/Reference/KeccakF-800-reference.c
+++ b/SnP/KeccakF-800/Reference/KeccakF-800-reference.c
@@ -126,7 +126,7 @@ void KeccakF800_StateComplementBit(void *state, unsigned int position)
     if (position < 800) {
         unsigned int bytePosition = position/8;
         unsigned int bitPosition = position%8;
-        
+
         ((unsigned char *)state)[bytePosition] ^= (UINT8)1 << bitPosition;
     }
 }
@@ -218,8 +218,8 @@ void theta(tKeccakLane *A)
     tKeccakLane C[5], D[5];
 
     for(x=0; x<5; x++) {
-        C[x] = 0; 
-        for(y=0; y<5; y++) 
+        C[x] = 0;
+        for(y=0; y<5; y++)
             C[x] ^= A[index(x, y)];
     }
     for(x=0; x<5; x++)
@@ -253,7 +253,7 @@ void chi(tKeccakLane *A)
     unsigned int x, y;
     tKeccakLane C[5];
 
-    for(y=0; y<5; y++) { 
+    for(y=0; y<5; y++) {
         for(x=0; x<5; x++)
             C[x] = A[index(x, y)] ^ ((~A[index(x+1, y)]) & A[index(x+2, y)]);
         for(x=0; x<5; x++)

--- a/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv6m-le-armcc.s
+++ b/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv6m-le-armcc.s
@@ -245,13 +245,13 @@ mSize	equ 6*4
 
 	load		$result,  0, 		$b, 0
 	load		r1, 	 $b, 		$g, 0
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	load		r1, 	 $g, 		$k, 0
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	load		r1,	 $k, 		$m, 0
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	load		r1,	 $m, 		$s, 1
-	eors		$result, $result, 	r1				
+	eors		$result, $result, 	r1
 	MEND
 
 	MACRO
@@ -690,7 +690,7 @@ KeccakF1600_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -796,7 +796,7 @@ KeccakF1600_StateXORBytesInLane_ToBitInterleavingConstants
 	dcd		0xCCCCCCCC
 	dcd		0xF0F0F0F0
 	dcd		0xFF00FF00
-KeccakF1600_StateXORBytesInLane_LengthNotZero	
+KeccakF1600_StateXORBytesInLane_LengthNotZero
 	mov		r4, r8
 	mov		r5, r9
 	push	{r4 - r5}
@@ -833,7 +833,7 @@ KeccakF1600_StateXORBytesInLane_Loop
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
 	adr		r3, KeccakF1600_StateOverwriteLanes_ToBitInterleavingConstants
 	cmp		r2, #0
 	bne		KeccakF1600_StateOverwriteLanes_LanesNotZero
@@ -928,7 +928,7 @@ KeccakF1600_StateOverwriteBytesInLane_ToBitInterleavingConstants
 	dcd		0xCCCCCCCC
 	dcd		0xF0F0F0F0
 	dcd		0xFF00FF00
-KeccakF1600_StateOverwriteBytesInLane_LengthNotZero	
+KeccakF1600_StateOverwriteBytesInLane_LengthNotZero
 	mov		r4, r8
 	mov		r5, r9
 	push	{r4 - r5}
@@ -974,7 +974,7 @@ KeccakF1600_StateOverwriteBytesInLane_Loop
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -1282,8 +1282,8 @@ KeccakP1600_StatePermute_Done
 ; Keccak_SnP_InterleaveByteAsm
 ; in:  r1   byte to be interleaved
 ;
-; out: r9	Least significant interleaved byte 
-;      r10  Most significant interleaved byte 
+; out: r9	Least significant interleaved byte
+;      r10  Most significant interleaved byte
 ;
 ; changed: r2, r3
 ;
@@ -1320,7 +1320,7 @@ Keccak_SnP_InterleaveByteAsm	PROC
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -1338,7 +1338,7 @@ KeccakP1600_12_SnP_FBWL_Absorb	PROC
 	bcc		KeccakP1600_12_SnP_FBWL_Absorb_Exit
 	mov		r4, r0
 	mov		r5, r1
-	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits
 	bl		Keccak_SnP_InterleaveByteAsm
 KeccakP1600_12_SnP_FBWL_Absorb_Loop
 	mov		r1, r6
@@ -1409,7 +1409,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -1428,7 +1428,7 @@ KeccakP1600_12_SnP_FBWL_Wrap	PROC
 	bcc		KeccakP1600_12_SnP_FBWL_Wrap_Exit
 	mov		r4, r3							; r4 dataOut pointer
 	mov		r5, r1							; r5 laneCount
-	ldr		r1, [sp, #(8+1)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+1)*4]				; Bit Interleave trailingBits
 	bl		Keccak_SnP_InterleaveByteAsm
 KeccakP1600_12_SnP_FBWL_Wrap_Loop
 	mov		r1, r6
@@ -1468,7 +1468,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -1492,7 +1492,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Start
 	push	{ r4 - r5 }
 	mov		r4, r3							; r4 dataOut pointer
 	mov		r5, r1							; r5 laneCount
-	ldr		r1, [sp, #(10+1)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; Bit Interleave trailingBits
 	bl		Keccak_SnP_InterleaveByteAsm
 KeccakP1600_12_SnP_FBWL_Unwrap_Loop
 	mov		lr, r5
@@ -1580,7 +1580,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_LanesDone
 	subs	r0, r0, r2
 	bl		KeccakP1600_12_StatePermute
 	subs	r7, r7, r5						; nbrLanes -= laneCount
-	bcc		KeccakP1600_12_SnP_FBWL_Unwrap_Done		
+	bcc		KeccakP1600_12_SnP_FBWL_Unwrap_Done
 	b		KeccakP1600_12_SnP_FBWL_Unwrap_Loop
 KeccakP1600_12_SnP_FBWL_Unwrap_Done
 	pop		{ r4 - r5 }

--- a/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv7a-le-armcc.s
+++ b/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv7a-le-armcc.s
@@ -14,7 +14,7 @@
 ;
 
 ; WARNING: These functions work only on little endian CPU with ARMv7a architecture (ARM Cortex-A8, ...).
- 
+
 ; INFO: Tested on a Cortex-A8 (BeagleBone Black)
 
     PRESERVE8
@@ -537,7 +537,7 @@ KeccakF1600_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -609,7 +609,7 @@ KeccakF1600_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
     cmp     r2, #0
     beq     KeccakF1600_StateOverwriteLanes_Exit
     push    {r4 - r11}
@@ -687,7 +687,7 @@ KeccakF1600_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -892,7 +892,7 @@ KeccakP1600_12_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -906,7 +906,7 @@ KeccakP1600_12_SnP_FBWL_Absorb	PROC
 	mov		r4, r0
 	mov		r5, r1
 	mov		r6, r2
-	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -970,7 +970,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -978,14 +978,14 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit
 KeccakP1600_12_SnP_FBWL_Wrap	PROC
 	push	{r4-r10,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(8+0)*4]				;  
+	ldr		r4, [sp, #(8+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcc		KeccakP1600_12_SnP_FBWL_Wrap_Exit
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(8+1)*4]				; r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+1)*4]				; r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1017,7 +1017,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Loop
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakP1600_12_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakP1600_12_SnP_FBWL_Wrap_Loop
 KeccakP1600_12_SnP_FBWL_Wrap_Exit
 	mov		r0, r8
@@ -1026,7 +1026,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -1034,7 +1034,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit
 KeccakP1600_12_SnP_FBWL_Unwrap	PROC
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				;  
+	ldr		r4, [sp, #(10+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcs		KeccakP1600_12_SnP_FBWL_Unwrap_WorkTodo
@@ -1044,7 +1044,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_WorkTodo
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				; r9,r12 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; r9,r12 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1073,7 +1073,7 @@ KeccakP1600_12_SnP_FBWL_UnwrapLane_Loop1
 	toBitInterleaving	r1, r2, r10, r11, r3, r4, r8, r9, r12, 1
 	ldrd	r2, r3, [r0]
 	strd	r10, r11, [r0], #8
-	eor		r2, r2, r10	
+	eor		r2, r2, r10
 	eor		r3, r3, r11
 	str		r2, [r7], #4
 	str		r3, [r7], #4
@@ -1105,7 +1105,7 @@ KeccakP1600_12_SnP_FBWL_UnwrapLane_Loop2
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakP1600_12_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakP1600_12_SnP_FBWL_Unwrap_Loop
 	mov		r0, r8
 	pop		{r4-r12,pc}

--- a/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv7a-le-gcc.s
+++ b/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv7a-le-gcc.s
@@ -14,10 +14,10 @@
 @
 
 @ WARNING: These functions work only on little endian CPU with@ ARMv7a architecture (ARM Cortex-A8, ...).
- 
+
 @ INFO: Tested on a Cortex-A8 (BeagleBone Black)
 
-   
+
 .text
 
     @// Credit: Henry S. Warren, Hacker's Delight, Addison-Wesley, 2002
@@ -472,7 +472,7 @@
 @//
 .align 8
 .global   KeccakF1600_Initialize
-KeccakF1600_Initialize:  
+KeccakF1600_Initialize:
 	bx		lr
 
 
@@ -482,7 +482,7 @@ KeccakF1600_Initialize:
 @//
 .align 8
 .global   KeccakF1600_StateInitialize
-KeccakF1600_StateInitialize:  
+KeccakF1600_StateInitialize:
 	push	{r4 - r5}
 	movs	r1, #0
 	movs	r2, #0
@@ -509,7 +509,7 @@ KeccakF1600_StateInitialize:
 @//
 .align 8
 .global   KeccakF1600_StateComplementBit
-KeccakF1600_StateComplementBit:  
+KeccakF1600_StateComplementBit:
 	and		r3, r1, #1
 	lsrs	r2, r1, #6
 	add		r0, r0, r3, LSL #2
@@ -526,10 +526,10 @@ KeccakF1600_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF1600_StateXORLanes
-KeccakF1600_StateXORLanes:  
+KeccakF1600_StateXORLanes:
     cmp     r2, #0
     beq     KeccakF1600_StateXORLanes_Exit
     push    {r4 - r11}
@@ -552,7 +552,7 @@ KeccakF1600_StateXORLanes_LoopAligned:
     pop     {r4 - r11}
 KeccakF1600_StateXORLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -560,7 +560,7 @@ KeccakF1600_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateXORBytesInLane
-KeccakF1600_StateXORBytesInLane:  
+KeccakF1600_StateXORBytesInLane:
     push    {r4 - r11}
     ldr     r7, [sp, #8*4]
     cmp     r7, #0
@@ -590,7 +590,7 @@ KeccakF1600_StateXORBytesInLane_Loop:
 KeccakF1600_StateXORBytesInLane_Exit:
     pop     {r4 - r11}
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -598,7 +598,7 @@ KeccakF1600_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes: 
+KeccakF1600_StateOverwriteLanes:
     cmp     r2, #0
     beq     KeccakF1600_StateOverwriteLanes_Exit
     push    {r4 - r11}
@@ -620,7 +620,7 @@ KeccakF1600_StateOverwriteLanes_LoopAligned:
     pop     {r4 - r11}
 KeccakF1600_StateOverwriteLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -668,7 +668,7 @@ KeccakF1600_StateOverwriteBytesInLane_Loop:
     pop     {r4 - r11}
 KeccakF1600_StateOverwriteBytesInLane_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -676,7 +676,7 @@ KeccakF1600_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes: 
+KeccakF1600_StateOverwriteWithZeroes:
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -710,7 +710,7 @@ KeccakF1600_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateExtractLanes
-KeccakF1600_StateExtractLanes:  
+KeccakF1600_StateExtractLanes:
     cmp     r2, #0
     beq     KeccakF1600_StateExtractLanes_Exit
     push    {r4 - r9}
@@ -731,7 +731,7 @@ KeccakF1600_StateExtractLanes_LoopAligned:
     pop     {r4 - r9}
 KeccakF1600_StateExtractLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -739,7 +739,7 @@ KeccakF1600_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF1600_StateExtractBytesInLane
-KeccakF1600_StateExtractBytesInLane:  
+KeccakF1600_StateExtractBytesInLane:
     push    {r4 - r9}
     ldr     r5, [sp, #6*4]
     cmp     r5, #0
@@ -766,7 +766,7 @@ KeccakF1600_StateExtractBytesInLane_Loop:
 KeccakF1600_StateExtractBytesInLane_Exit:
     pop     {r4 - r9}
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -799,7 +799,7 @@ KeccakF1600_StateExtractAndXORLanes_LoopAligned:
     pop     {r4 - r9}
 KeccakF1600_StateExtractAndXORLanes_Exit:
     bx      lr
-   
+
 
 @//----------------------------------------------------------------------------
 @//
@@ -836,7 +836,7 @@ KeccakF1600_StateExtractAndXORBytesInLane_Loop:
 KeccakF1600_StateExtractAndXORBytesInLane_Exit:
     pop     {r4 - r9}
     bx      lr
-   
+
 
 .align 8
 KeccakP1600_12_StatePermute_RoundConstantsWithTerminator:
@@ -864,7 +864,7 @@ KeccakP1600_12_StatePermute_RoundConstantsWithTerminator:
 @//
 .align 8
 .global   KeccakP1600_12_StatePermute
-KeccakP1600_12_StatePermute:  
+KeccakP1600_12_StatePermute:
     adr     r1, KeccakP1600_12_StatePermute_RoundConstantsWithTerminator
     push    { r4 - r12, lr }
     sub     sp, #mSize
@@ -877,11 +877,11 @@ KeccakP1600_12_StatePermute_RoundLoop:
     bne     KeccakP1600_12_StatePermute_RoundLoop
     add     sp, #mSize
     pop     { r4 - r12, pc }
-   
+
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+@ size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 @										size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -895,7 +895,7 @@ KeccakP1600_12_SnP_FBWL_Absorb:
 	mov		r4, r0
 	mov		r5, r1
 	mov		r6, r2
-	ldr		r1, [sp, #(8+0)*4]				@ Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				@ Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -959,7 +959,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 @
 .align 8
@@ -967,14 +967,14 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit:
 KeccakP1600_12_SnP_FBWL_Wrap:
 	push	{r4-r10,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(8+0)*4]				@  
+	ldr		r4, [sp, #(8+0)*4]				@
 	lsr		r4, r4, #3						@ r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						@ .if (nbrLanes >== laneCount)
 	bcc		KeccakP1600_12_SnP_FBWL_Wrap_Exit
 	mov		r5, r1							@ r5: laneCount
 	mov		r6, r2							@ r6: dataIn
 	mov		r7, r3							@ r7: dataOut
-	ldr		r1, [sp, #(8+1)*4]				@ r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+1)*4]				@ r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1006,7 +1006,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Loop:
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					@ state pointer back to initial position
 	bl		KeccakP1600_12_StatePermute
-	subs	r4, r4, r5						@ dec nbrLanes 
+	subs	r4, r4, r5						@ dec nbrLanes
 	bcs		KeccakP1600_12_SnP_FBWL_Wrap_Loop
 KeccakP1600_12_SnP_FBWL_Wrap_Exit:
 	mov		r0, r8
@@ -1015,7 +1015,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit:
 
 @----------------------------------------------------------------------------
 @
-@ size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+@ size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 @										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 @
 .align 8
@@ -1023,7 +1023,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit:
 KeccakP1600_12_SnP_FBWL_Unwrap:
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				@  
+	ldr		r4, [sp, #(10+0)*4]				@
 	lsr		r4, r4, #3						@ r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						@ .if (nbrLanes >== laneCount)
 	bcs		KeccakP1600_12_SnP_FBWL_Unwrap_WorkTodo
@@ -1033,7 +1033,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_WorkTodo:
 	mov		r5, r1							@ r5: laneCount
 	mov		r6, r2							@ r6: dataIn
 	mov		r7, r3							@ r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				@ r9,r12 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				@ r9,r12 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1062,7 +1062,7 @@ KeccakP1600_12_SnP_FBWL_UnwrapLane_Loop1:
 	toBitInterleaving	r1, r2, r10, r11, r3, r4, r8, r9, r12, 1
 	ldrd	r2, r3, [r0]
 	strd	r10, r11, [r0], #8
-	eor		r2, r2, r10	
+	eor		r2, r2, r10
 	eor		r3, r3, r11
 	str		r2, [r7], #4
 	str		r3, [r7], #4
@@ -1094,7 +1094,7 @@ KeccakP1600_12_SnP_FBWL_UnwrapLane_Loop2:
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					@ state pointer back to initial position
 	bl		KeccakP1600_12_StatePermute
-	subs	r4, r4, r5						@ dec nbrLanes 
+	subs	r4, r4, r5						@ dec nbrLanes
 	bcs		KeccakP1600_12_SnP_FBWL_Unwrap_Loop
 	mov		r0, r8
 	pop		{r4-r12,pc}

--- a/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv7m-le-armcc.s
+++ b/SnP/KeccakP-1600-12/Optimized32biAsmARM/KeccakP-1600-12-inplace-32bi-armv7m-le-armcc.s
@@ -190,11 +190,11 @@ mSize	equ 6*4
 
 	ldr			$result, [r0, #$b]
 	ldr			r1, [r0, #$g]
-	eors		$result, $result, r1				
+	eors		$result, $result, r1
 	ldr			r1, [r0, #$k]
 	eors		$result, $result, r1
 	ldr			r1, [r0, #$m]
-	eors		$result, $result, r1				
+	eors		$result, $result, r1
 	ldr			r1, [r0, #$s]
 	eors		$result, $result, r1
 	MEND
@@ -537,7 +537,7 @@ KeccakF1600_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -593,7 +593,7 @@ KeccakF1600_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
 	cmp		r2, #0
 	beq		KeccakF1600_StateOverwriteLanes_Exit
 	push	{r4 - r7}
@@ -655,7 +655,7 @@ KeccakF1600_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	push	{r4 - r5}
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
@@ -832,7 +832,7 @@ KeccakP1600_12_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -846,7 +846,7 @@ KeccakP1600_12_SnP_FBWL_Absorb	PROC
 	mov		r4, r0
 	mov		r5, r1
 	mov		r6, r2
-	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits 
+	ldr		r1, [sp, #(8+0)*4]				; Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -910,7 +910,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -918,7 +918,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Exit
 KeccakP1600_12_SnP_FBWL_Wrap	PROC
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				;  
+	ldr		r4, [sp, #(10+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcs		KeccakP1600_12_SnP_FBWL_Wrap_Go
@@ -927,7 +927,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Go
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -960,7 +960,7 @@ KeccakP1600_12_SnP_FBWL_WrapLane_Loop
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakP1600_12_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakP1600_12_SnP_FBWL_Wrap_Loop
 KeccakP1600_12_SnP_FBWL_Wrap_Exit
 	mov		r0, r8
@@ -969,7 +969,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -977,7 +977,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Exit
 KeccakP1600_12_SnP_FBWL_Unwrap	PROC
 	push	{r4-r12,lr}
 	mov		r8, #0
-	ldr		r4, [sp, #(10+0)*4]				;  
+	ldr		r4, [sp, #(10+0)*4]				;
 	lsr		r4, r4, #3						; r4: nbrLanes = dataByteLen / SnP_laneLengthInBytes
 	subs	r4, r4, r1						; if (nbrLanes >= laneCount)
 	bcs		KeccakP1600_12_SnP_FBWL_Unwrap_Go
@@ -986,7 +986,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Go
 	mov		r5, r1							; r5: laneCount
 	mov		r6, r2							; r6: dataIn
 	mov		r7, r3							; r7: dataOut
-	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits 
+	ldr		r1, [sp, #(10+1)*4]				; r9,r10 Bit Interleave trailingBits
 	and		r2, r1, #0x55
 	orr		r2, r2, r2, LSR #1
 	and		r2, r2, #0x33
@@ -1023,7 +1023,7 @@ KeccakP1600_12_SnP_FBWL_UnwrapLane_Loop
 	str		r1, [r0, #4]
 	sub		r0, r5, LSL #3					; state pointer back to initial position
 	bl		KeccakP1600_12_StatePermute
-	subs	r4, r4, r5						; dec nbrLanes 
+	subs	r4, r4, r5						; dec nbrLanes
 	bcs		KeccakP1600_12_SnP_FBWL_Unwrap_Loop
 KeccakP1600_12_SnP_FBWL_Unwrap_Exit
 	mov		r0, r8

--- a/SnP/KeccakP-1600-12/OptimizedAsmARM/KeccakP-1600-12-armv7a-le-neon-armcc.s
+++ b/SnP/KeccakP-1600-12/OptimizedAsmARM/KeccakP-1600-12-armv7a-le-neon-armcc.s
@@ -13,7 +13,7 @@
 ; http://creativecommons.org/publicdomain/zero/1.0/
 ;
 
-; WARNING: These functions work only on little endian CPU with ARMv7A + NEON architecture 
+; WARNING: These functions work only on little endian CPU with ARMv7A + NEON architecture
 ; WARNING: State must be 256 bit (32 bytes) aligned, best is 64-byte (cache alignment).
 ; INFO: Tested on Cortex-A8 (BeagleBone Black), using gcc.
 
@@ -145,7 +145,7 @@ _su		equ 24*8
 	MEND
 
     MACRO
-    KeccakRound	
+    KeccakRound
 
     ;Prepare Theta
     veor.64     q13, q0, q5
@@ -224,16 +224,16 @@ _su		equ 24*8
 
 	RhoPi4		d2, d3, 44, d4, d14, 43, d8, d24, 14, d6, d17, 21	;  1 <  6,  2 < 12,  4 < 24,  3 < 18
 	RhoPi4		d3, d9, 20, d14, d16, 25, d24, d21,  2, d17, d15, 15	;  6 <  9, 12 < 13, 24 < 21, 18 < 17
-	RhoPi4		d9, d22, 61, d16, d19,  8, d21, d7, 55, d15, d12, 10	;  9 < 22, 13 < 19, 21 <  8, 17 < 11	
+	RhoPi4		d9, d22, 61, d16, d19,  8, d21, d7, 55, d15, d12, 10	;  9 < 22, 13 < 19, 21 <  8, 17 < 11
 	RhoPi4		d22, d18, 39, d19, d23, 56, d7, d13, 45, d12, d5,  6	; 22 < 14, 19 < 23,  8 < 16, 11 < 7
 	RhoPi4		d18, d20, 18, d23, d11, 41, d13, d1, 36, d5, d10,  3	; 14 < 20, 23 < 15, 16 <  5,  7 < 10
 	RhoPi4		d20, d28, 62, d11, d25, 27, d1, d29, 28, d10, d27,  1	; 20 <  2, 15 <  4,  5 <  3, 10 < 1
-	
+
 	;Chi	b+g
-	vmov.i64	q13, q0			
+	vmov.i64	q13, q0
     vbic.64     q15, q2, q1	; ba ^= ~be & bi
 	veor.64		q0, q15
-	vmov.i64	q14, q1			
+	vmov.i64	q14, q1
     vbic.64     q15, q3, q2	; be ^= ~bi & bo
 	veor.64		q1, q15
     vbic.64     q15, q4, q3	; bi ^= ~bo & bu
@@ -244,10 +244,10 @@ _su		equ 24*8
  	veor.64		q4, q13
 
 	;Chi	k+m
-	vmov.i64	q13, q5			
+	vmov.i64	q13, q5
     vbic.64     q15, q7, q6	; ba ^= ~be & bi
 	veor.64		q5, q15
-	vmov.i64	q14, q6			
+	vmov.i64	q14, q6
     vbic.64     q15, q8, q7	; be ^= ~bi & bo
 	veor.64		q6, q15
     vbic.64     q15, q9, q8	; bi ^= ~bo & bu
@@ -258,7 +258,7 @@ _su		equ 24*8
  	veor.64		q9, q13
 
 	;Chi	s
-	vmov.i64	q13, q10			
+	vmov.i64	q13, q10
     vbic.64     d30,  d22,  d21	; ba ^= ~be & bi
     vbic.64     d31,  d23,  d22	; be ^= ~bi & bo
 	veor.64		q10, q15
@@ -295,7 +295,7 @@ KeccakF1600_StateInitialize   PROC
     vstm        r0!, { d0 - d7 }            ; clear 8 lanes at a time
     vstm        r0!, { d0 - d7 }
     vstm        r0!, { d0 - d7 }
-    vstm        r0!, { d0 }    
+    vstm        r0!, { d0 }
     bx          lr
     ENDP
 
@@ -319,7 +319,7 @@ KeccakF1600_StateComplementBit   PROC
 ;----------------------------------------------------------------------------
 ;
 ; void KeccakF1600_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-; 
+;
     ALIGN
 	EXPORT  KeccakF1600_StateXORLanes
 KeccakF1600_StateXORLanes   PROC
@@ -369,7 +369,7 @@ KeccakF1600_StateXORBytesInLane_Exit
 ;
     ALIGN
 	EXPORT  KeccakF1600_StateOverwriteLanes
-KeccakF1600_StateOverwriteLanes	PROC 
+KeccakF1600_StateOverwriteLanes	PROC
     cmp     r2, #0
     beq     KeccakF1600_StateOverwriteLanes_Exit
     push    {r4 - r5}
@@ -411,13 +411,13 @@ KeccakF1600_StateOverwriteBytesInLane_Exit
 ;
     ALIGN
 	EXPORT  KeccakF1600_StateOverwriteWithZeroes
-KeccakF1600_StateOverwriteWithZeroes	PROC 
+KeccakF1600_StateOverwriteWithZeroes	PROC
 	lsrs	r2, r1, #3
 	beq		KeccakF1600_StateOverwriteWithZeroes_Bytes
     vmov.i64 d0, #0
 KeccakF1600_StateOverwriteWithZeroes_LoopLanes
 	subs	r2, r2, #1
-    vstm    r0!, { d0 }    
+    vstm    r0!, { d0 }
 	bne		KeccakF1600_StateOverwriteWithZeroes_LoopLanes
 KeccakF1600_StateOverwriteWithZeroes_Bytes
 	ands	r1, #7
@@ -650,7 +650,7 @@ KeccakP1600_12_StatePermute   PROC
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP1600_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -942,7 +942,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_LoopLessThan16Lanes
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -973,54 +973,54 @@ KeccakP1600_12_SnP_FBWL_Wrap_Loop21Lanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
-    vst1.64	{ d2 }, [r3]!	
-    vst1.64	{ d4 }, [r3]!	
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
+    vst1.64	{ d2 }, [r3]!
+    vst1.64	{ d4 }, [r3]!
+    vst1.64	{ d6 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d8, d8, d26
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
-    vst1.64	{ d1 }, [r3]!	
-    vst1.64	{ d3 }, [r3]!	
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
+    vst1.64	{ d1 }, [r3]!
+    vst1.64	{ d3 }, [r3]!
+    vst1.64	{ d5 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d7, d7, d26
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
-    vst1.64	{ d9 }, [r3]!	
-    vst1.64	{ d10 }, [r3]!	
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
+    vst1.64	{ d9 }, [r3]!
+    vst1.64	{ d10 }, [r3]!
+    vst1.64	{ d12 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d14, d14, d26
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
-    vst1.64	{ d16 }, [r3]!	
-    vst1.64	{ d18 }, [r3]!	
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
+    vst1.64	{ d16 }, [r3]!
+    vst1.64	{ d18 }, [r3]!
+    vst1.64	{ d11 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d13, d13, d26
 	veor.64	d15, d15, d27
 	veor.64	d17, d17, d28
 	veor.64	d19, d19, d29
-    vst1.64	{ d13 }, [r3]!	
-    vst1.64	{ d15 }, [r3]!	
-    vst1.64	{ d17 }, [r3]!	
-    vst1.64	{ d19 }, [r3]!	
+    vst1.64	{ d13 }, [r3]!
+    vst1.64	{ d15 }, [r3]!
+    vst1.64	{ d17 }, [r3]!
+    vst1.64	{ d19 }, [r3]!
 
     vld1.64	{ d26 }, [r6]!
 	veor.64	d20, d20, d26
-    vst1.64	{ d20 }, [r3]!	
+    vst1.64	{ d20 }, [r3]!
 
 	vld1.64	{d30}, [sp:64]					; xor trailingBits
 	veor.64	d21, d21, d30
@@ -1044,40 +1044,40 @@ KeccakP1600_12_SnP_FBWL_Wrap_Loop16OrMoreLanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
-    vst1.64	{ d2 }, [r3]!	
-    vst1.64	{ d4 }, [r3]!	
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
+    vst1.64	{ d2 }, [r3]!
+    vst1.64	{ d4 }, [r3]!
+    vst1.64	{ d6 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d8, d8, d26
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
-    vst1.64	{ d1 }, [r3]!	
-    vst1.64	{ d3 }, [r3]!	
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
+    vst1.64	{ d1 }, [r3]!
+    vst1.64	{ d3 }, [r3]!
+    vst1.64	{ d5 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d7, d7, d26
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
-    vst1.64	{ d9 }, [r3]!	
-    vst1.64	{ d10 }, [r3]!	
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
+    vst1.64	{ d9 }, [r3]!
+    vst1.64	{ d10 }, [r3]!
+    vst1.64	{ d12 }, [r3]!
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
 	veor.64	d14, d14, d26
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
-    vst1.64	{ d16 }, [r3]!	
-    vst1.64	{ d18 }, [r3]!	
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
+    vst1.64	{ d16 }, [r3]!
+    vst1.64	{ d18 }, [r3]!
+    vst1.64	{ d11 }, [r3]!
 
 	sub		r2, r5, #16							; XOR last n lanes, maximum 9
 	rsb		r1, r2, #9
@@ -1189,7 +1189,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_LoopLessThan16Lanes
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -1220,13 +1220,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
 	vmov.64	d0, d26
-    vst1.64	{ d2 }, [r3]!	
+    vst1.64	{ d2 }, [r3]!
 	vmov.64	d2, d27
-    vst1.64	{ d4 }, [r3]!	
+    vst1.64	{ d4 }, [r3]!
 	vmov.64	d4, d28
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d6 }, [r3]!
 	vmov.64	d6, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1234,13 +1234,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
 	vmov.64	d8, d26
-    vst1.64	{ d1 }, [r3]!	
+    vst1.64	{ d1 }, [r3]!
 	vmov.64	d1, d27
-    vst1.64	{ d3 }, [r3]!	
+    vst1.64	{ d3 }, [r3]!
 	vmov.64	d3, d28
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d5 }, [r3]!
 	vmov.64	d5, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1248,13 +1248,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
 	vmov.64	d7, d26
-    vst1.64	{ d9 }, [r3]!	
+    vst1.64	{ d9 }, [r3]!
 	vmov.64	d9, d27
-    vst1.64	{ d10 }, [r3]!	
+    vst1.64	{ d10 }, [r3]!
 	vmov.64	d10, d28
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d12 }, [r3]!
 	vmov.64	d12, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1262,13 +1262,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
 	vmov.64	d14, d26
-    vst1.64	{ d16 }, [r3]!	
+    vst1.64	{ d16 }, [r3]!
 	vmov.64	d16, d27
-    vst1.64	{ d18 }, [r3]!	
+    vst1.64	{ d18 }, [r3]!
 	vmov.64	d18, d28
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d11 }, [r3]!
 	vmov.64	d11, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1276,18 +1276,18 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21Lanes
 	veor.64	d15, d15, d27
 	veor.64	d17, d17, d28
 	veor.64	d19, d19, d29
-    vst1.64	{ d13 }, [r3]!	
+    vst1.64	{ d13 }, [r3]!
 	vmov.64	d13, d26
-    vst1.64	{ d15 }, [r3]!	
+    vst1.64	{ d15 }, [r3]!
 	vmov.64	d15, d27
-    vst1.64	{ d17 }, [r3]!	
+    vst1.64	{ d17 }, [r3]!
 	vmov.64	d17, d28
-    vst1.64	{ d19 }, [r3]!	
+    vst1.64	{ d19 }, [r3]!
 	vmov.64	d19, d29
 
     vld1.64	{ d26 }, [r6]!
 	veor.64	d20, d20, d26
-    vst1.64	{ d20 }, [r3]!	
+    vst1.64	{ d20 }, [r3]!
 	vmov.64	d20, d26
 
 	vld1.64	{d30}, [sp:64]					; xor trailingBits
@@ -1312,13 +1312,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d2, d2, d27
 	veor.64	d4, d4, d28
 	veor.64	d6, d6, d29
-    vst1.64	{ d0 }, [r3]!	
+    vst1.64	{ d0 }, [r3]!
 	vmov.64	d0, d26
-    vst1.64	{ d2 }, [r3]!	
+    vst1.64	{ d2 }, [r3]!
 	vmov.64	d2, d27
-    vst1.64	{ d4 }, [r3]!	
+    vst1.64	{ d4 }, [r3]!
 	vmov.64	d4, d28
-    vst1.64	{ d6 }, [r3]!	
+    vst1.64	{ d6 }, [r3]!
 	vmov.64	d6, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1326,13 +1326,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d1, d1, d27
 	veor.64	d3, d3, d28
 	veor.64	d5, d5, d29
-    vst1.64	{ d8 }, [r3]!	
+    vst1.64	{ d8 }, [r3]!
 	vmov.64	d8, d26
-    vst1.64	{ d1 }, [r3]!	
+    vst1.64	{ d1 }, [r3]!
 	vmov.64	d1, d27
-    vst1.64	{ d3 }, [r3]!	
+    vst1.64	{ d3 }, [r3]!
 	vmov.64	d3, d28
-    vst1.64	{ d5 }, [r3]!	
+    vst1.64	{ d5 }, [r3]!
 	vmov.64	d5, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1340,13 +1340,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d9, d9, d27
 	veor.64	d10, d10, d28
 	veor.64	d12, d12, d29
-    vst1.64	{ d7 }, [r3]!	
+    vst1.64	{ d7 }, [r3]!
 	vmov.64	d7, d26
-    vst1.64	{ d9 }, [r3]!	
+    vst1.64	{ d9 }, [r3]!
 	vmov.64	d9, d27
-    vst1.64	{ d10 }, [r3]!	
+    vst1.64	{ d10 }, [r3]!
 	vmov.64	d10, d28
-    vst1.64	{ d12 }, [r3]!	
+    vst1.64	{ d12 }, [r3]!
 	vmov.64	d12, d29
 
     vld1.64	{ d26, d27, d28, d29 }, [r6]!
@@ -1354,13 +1354,13 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop16OrMoreLanes
 	veor.64	d16, d16, d27
 	veor.64	d18, d18, d28
 	veor.64	d11, d11, d29
-    vst1.64	{ d14 }, [r3]!	
+    vst1.64	{ d14 }, [r3]!
 	vmov.64	d14, d26
-    vst1.64	{ d16 }, [r3]!	
+    vst1.64	{ d16 }, [r3]!
 	vmov.64	d16, d27
-    vst1.64	{ d18 }, [r3]!	
+    vst1.64	{ d18 }, [r3]!
 	vmov.64	d18, d28
-    vst1.64	{ d11 }, [r3]!	
+    vst1.64	{ d11 }, [r3]!
 	vmov.64	d11, d29
 
 	sub		r2, r5, #16							; XOR last n lanes, maximum 9

--- a/SnP/KeccakP-1600-12/OptimizedAsmAVR8/KeccakP-1600-12-avr8-compact.s
+++ b/SnP/KeccakP-1600-12/OptimizedAsmAVR8/KeccakP-1600-12-avr8-compact.s
@@ -679,7 +679,7 @@ Keccak_Done:
     ret
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakP-1600-12/OptimizedAsmAVR8/KeccakP-1600-12-avr8-fast.s
+++ b/SnP/KeccakP-1600-12/OptimizedAsmAVR8/KeccakP-1600-12-avr8-fast.s
@@ -1065,7 +1065,7 @@ rotate64_7byte_left:
     #undef  pRound
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakP-1600-12/OptimizedAsmX86-64/KeccakP-1600-12-x86-64-gas.s
+++ b/SnP/KeccakP-1600-12/OptimizedAsmX86-64/KeccakP-1600-12-x86-64-gas.s
@@ -79,7 +79,7 @@
 .equ rDo, %r8
 .equ rDu, %r9
 
-.equ rBa, %r10 
+.equ rBa, %r10
 .equ rBe, %r11
 .equ rBi, %r12
 .equ rBo, %r13
@@ -125,7 +125,7 @@
     xorq    rCi, rDo
     rolq    rDu
 
-    # Theta Rho Pi Chi Iota, result b 
+    # Theta Rho Pi Chi Iota, result b
     movq    _ba(\iState), rBa
     movq    _ge(\iState), rBe
     xorq    rCo, rDu
@@ -170,7 +170,7 @@
     movq    rBi, rCe
     .endif
 
-    # Theta Rho Pi Chi, result g 
+    # Theta Rho Pi Chi, result g
     movq    _gu(\iState), rBe
     xorq    rDu, rBe
     movq    _ka(\iState), rBi
@@ -375,27 +375,27 @@
 
     subq    $8*25, %rsp
 
-    movq    _ba(rpState), rCa             
+    movq    _ba(rpState), rCa
     movq    _be(rpState), rCe
     movq    _bu(rpState), rCu
 
-    xorq    _ga(rpState), rCa             
+    xorq    _ga(rpState), rCa
     xorq    _ge(rpState), rCe
-    xorq    _gu(rpState), rCu             
+    xorq    _gu(rpState), rCu
 
-    xorq    _ka(rpState), rCa             
+    xorq    _ka(rpState), rCa
     xorq    _ke(rpState), rCe
-    xorq    _ku(rpState), rCu             
+    xorq    _ku(rpState), rCu
 
-    xorq    _ma(rpState), rCa             
+    xorq    _ma(rpState), rCa
     xorq    _me(rpState), rCe
-    xorq    _mu(rpState), rCu             
+    xorq    _mu(rpState), rCu
 
     xorq    _sa(rpState), rCa
     xorq    _se(rpState), rCe
     movq    _si(rpState), rDi
     movq    _so(rpState), rDo
-    xorq    _su(rpState), rCu             
+    xorq    _su(rpState), rCu
 
     mKeccakRound    rpState, rpStack, 0x000000008000808b, 0
     mKeccakRound    rpStack, rpState, 0x800000000000008b, 0
@@ -566,7 +566,7 @@ KeccakF1600_StateInitialize:
 
 KeccakPowerOf2:
     .byte   1, 2, 4, 8, 16, 32, 64, 128
-   
+
 #----------------------------------------------------------------------------
 #
 #    void KeccakF1600_StateComplementBit(void *state, unsigned int position)
@@ -587,7 +587,7 @@ KeccakF1600_StateComplementBit:
 #----------------------------------------------------------------------------
 #
 # void KeccakF1600_StateXORBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
-# 
+#
     .size   KeccakF1600_StateXORBytes, .-KeccakF1600_StateXORBytes
     .align  8
     .global KeccakF1600_StateXORBytes
@@ -844,7 +844,7 @@ KeccakP1600_12_StatePermute:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakP1600_12_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data, 
+# size_t KeccakP1600_12_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data,
 #                                     size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakP1600_12_SnP_FBWL_Absorb, .-KeccakP1600_12_SnP_FBWL_Absorb
@@ -925,7 +925,7 @@ KeccakP1600_12_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg2
     pushq   arg1
     movq    arg2, arg4                  # prepare xor call: length (in bytes)
-    shlq    $3, arg4                    
+    shlq    $3, arg4
     movq    arg3, arg2                  # data pointer
     xorq    arg3, arg3                  # offset = 0
     callq   KeccakF1600_StateXORBytes   #  (void *state, const unsigned char *data, unsigned int offset, unsigned int length)
@@ -936,7 +936,7 @@ KeccakP1600_12_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg3
     callq   KeccakP1600_12_StatePermute
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg4
     subq    arg2, arg4                  # while (nbrLanes >= 21)
     jnc     KeccakP1600_12_SnP_FBWL_Absorb_VariableLaneCountLoop
@@ -963,12 +963,12 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Loop21:    # Fixed laneCount = 21 (rate = 1344, 
     pushq   arg3
     mKeccakPermutationInlinable
     popq    arg3
-    
+
     movq    _ba(arg1), rT1a
     movq    _be(arg1), rT1e
     movq    _bi(arg1), rT1i
     movq    _bo(arg1), rT1o
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _bu(arg1), rT1u
     movq    rT1a, _ba(arg3)
@@ -1048,7 +1048,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                   unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakP1600_12_SnP_FBWL_Wrap, .-KeccakP1600_12_SnP_FBWL_Wrap
@@ -1080,7 +1080,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Loop21:       # Fixed laneCount = 21 (rate = 1344, 
     movq    rT1i, _bi(arg1)
     movq    rT1o, _bo(arg1)
     movq    rT1u, _bu(arg1)
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    rT1a, _ba(arg4)
     movq    rT1e, _be(arg4)
@@ -1213,7 +1213,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_VariableLaneCountLoop:
     popq    arg4
     popq    arg3
 
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakP1600_12_SnP_FBWL_Wrap_VariableLaneCountLoop
@@ -1221,7 +1221,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                     unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 #
     .size   KeccakP1600_12_SnP_FBWL_Unwrap, .-KeccakP1600_12_SnP_FBWL_Unwrap
@@ -1245,7 +1245,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21:     # Fixed laneCount = 21 (rate = 1344, 
     movq    _bi(arg3), rT1i
     movq    _bo(arg3), rT1o
     movq    _bu(arg3), rT1u
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _ba(arg1), rT2a
     movq    _be(arg1), rT2e
@@ -1402,7 +1402,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_VariableLaneCount_LaneLoop:
     callq   KeccakP1600_12_StatePermute
     popq    arg4
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakP1600_12_SnP_FBWL_Unwrap_VariableLaneCountLoop

--- a/SnP/KeccakP-1600-12/OptimizedAsmX86-64/KeccakP-1600-12-x86-64-shld-gas.s
+++ b/SnP/KeccakP-1600-12/OptimizedAsmX86-64/KeccakP-1600-12-x86-64-shld-gas.s
@@ -79,7 +79,7 @@
 .equ rDo,		%r8
 .equ rDu,		%r9
 
-.equ rBa,		%r10 
+.equ rBa,		%r10
 .equ rBe,		%r11
 .equ rBi,		%r12
 .equ rBo,		%r13
@@ -125,7 +125,7 @@
     xorq    rCi, rDo
     shld    $1, rDu, rDu
 
-    # Theta Rho Pi Chi Iota, result b 
+    # Theta Rho Pi Chi Iota, result b
     movq    _ba(\iState), rBa
     movq    _ge(\iState), rBe
     xorq    rCo, rDu
@@ -170,7 +170,7 @@
     movq    rBi, rCe
     .endif
 
-    # Theta Rho Pi Chi, result g 
+    # Theta Rho Pi Chi, result g
     movq    _gu(\iState), rBe
     xorq    rDu, rBe
     movq    _ka(\iState), rBi
@@ -375,27 +375,27 @@
 
     subq    $8*25, %rsp
 
-    movq    _ba(rpState), rCa             
+    movq    _ba(rpState), rCa
     movq    _be(rpState), rCe
     movq    _bu(rpState), rCu
 
-    xorq    _ga(rpState), rCa             
+    xorq    _ga(rpState), rCa
     xorq    _ge(rpState), rCe
-    xorq    _gu(rpState), rCu             
+    xorq    _gu(rpState), rCu
 
-    xorq    _ka(rpState), rCa             
+    xorq    _ka(rpState), rCa
     xorq    _ke(rpState), rCe
-    xorq    _ku(rpState), rCu             
+    xorq    _ku(rpState), rCu
 
-    xorq    _ma(rpState), rCa             
+    xorq    _ma(rpState), rCa
     xorq    _me(rpState), rCe
-    xorq    _mu(rpState), rCu             
+    xorq    _mu(rpState), rCu
 
     xorq    _sa(rpState), rCa
     xorq    _se(rpState), rCe
     movq    _si(rpState), rDi
     movq    _so(rpState), rDo
-    xorq    _su(rpState), rCu             
+    xorq    _su(rpState), rCu
 
     mKeccakRound    rpState, rpStack, 0x000000008000808b, 0
     mKeccakRound    rpStack, rpState, 0x800000000000008b, 0
@@ -566,7 +566,7 @@ KeccakF1600_StateInitialize:
 
 KeccakPowerOf2:
     .byte   1, 2, 4, 8, 16, 32, 64, 128
-   
+
 #----------------------------------------------------------------------------
 #
 #    void KeccakF1600_StateComplementBit(void *state, unsigned int position)
@@ -587,7 +587,7 @@ KeccakF1600_StateComplementBit:
 #----------------------------------------------------------------------------
 #
 # void KeccakF1600_StateXORBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
-# 
+#
     .size   KeccakF1600_StateXORBytes, .-KeccakF1600_StateXORBytes
     .align  8
     .global KeccakF1600_StateXORBytes
@@ -844,7 +844,7 @@ KeccakP1600_12_StatePermute:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakP1600_12_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data, 
+# size_t KeccakP1600_12_SnP_FBWL_Absorb( void *state, unsigned int laneCount, unsigned char *data,
 #                                     size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakP1600_12_SnP_FBWL_Absorb, .-KeccakP1600_12_SnP_FBWL_Absorb
@@ -925,7 +925,7 @@ KeccakP1600_12_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg2
     pushq   arg1
     movq    arg2, arg4                  # prepare xor call: length (in bytes)
-    shlq    $3, arg4                    
+    shlq    $3, arg4
     movq    arg3, arg2                  # data pointer
     xorq    arg3, arg3                  # offset = 0
     callq   KeccakF1600_StateXORBytes   #  (void *state, const unsigned char *data, unsigned int offset, unsigned int length)
@@ -936,7 +936,7 @@ KeccakP1600_12_SnP_FBWL_Absorb_VariableLaneCountLoop:
     pushq   arg3
     callq   KeccakP1600_12_StatePermute
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg4
     subq    arg2, arg4                  # while (nbrLanes >= 21)
     jnc     KeccakP1600_12_SnP_FBWL_Absorb_VariableLaneCountLoop
@@ -963,12 +963,12 @@ KeccakP1600_12_SnP_FBWL_Squeeze_Loop21:    # Fixed laneCount = 21 (rate = 1344, 
     pushq   arg3
     mKeccakPermutationInlinable
     popq    arg3
-    
+
     movq    _ba(arg1), rT1a
     movq    _be(arg1), rT1e
     movq    _bi(arg1), rT1i
     movq    _bo(arg1), rT1o
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _bu(arg1), rT1u
     movq    rT1a, _ba(arg3)
@@ -1048,7 +1048,7 @@ KeccakP1600_12_SnP_FBWL_Squeeze_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakP1600_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                   unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 #
     .size   KeccakP1600_12_SnP_FBWL_Wrap, .-KeccakP1600_12_SnP_FBWL_Wrap
@@ -1080,7 +1080,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_Loop21:       # Fixed laneCount = 21 (rate = 1344, 
     movq    rT1i, _bi(arg1)
     movq    rT1o, _bo(arg1)
     movq    rT1u, _bu(arg1)
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    rT1a, _ba(arg4)
     movq    rT1e, _be(arg4)
@@ -1213,7 +1213,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_VariableLaneCountLoop:
     popq    arg4
     popq    arg3
 
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakP1600_12_SnP_FBWL_Wrap_VariableLaneCountLoop
@@ -1221,7 +1221,7 @@ KeccakP1600_12_SnP_FBWL_Wrap_VariableLaneCountLoop:
 
 #----------------------------------------------------------------------------
 #
-# size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+# size_t KeccakP1600_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 #                                     unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 #
     .size   KeccakP1600_12_SnP_FBWL_Unwrap, .-KeccakP1600_12_SnP_FBWL_Unwrap
@@ -1245,7 +1245,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_Loop21:     # Fixed laneCount = 21 (rate = 1344, 
     movq    _bi(arg3), rT1i
     movq    _bo(arg3), rT1o
     movq    _bu(arg3), rT1u
-    notq    rT1e                # be 
+    notq    rT1e                # be
     notq    rT1i                # bi
     movq    _ba(arg1), rT2a
     movq    _be(arg1), rT2e
@@ -1402,7 +1402,7 @@ KeccakP1600_12_SnP_FBWL_Unwrap_VariableLaneCount_LaneLoop:
     callq   KeccakP1600_12_StatePermute
     popq    arg4
     popq    arg3
-    popq    arg2    
+    popq    arg2
     popq    arg5
     subq    arg2, arg5                  # while (nbrLanes >= 21)
     jnc     KeccakP1600_12_SnP_FBWL_Unwrap_VariableLaneCountLoop

--- a/SnP/KeccakP-200/Compact/KeccakP-200-compact.c
+++ b/SnP/KeccakP-200/Compact/KeccakP-200-compact.c
@@ -34,20 +34,20 @@ typedef UINT8 tKeccakLane;
 
 #define ROL8(a, offset) (UINT8)((((UINT8)a) << (offset&7)) ^ (((UINT8)a) >> (8-(offset&7))))
 
-const UINT8 KeccakF_RotationConstants[25] = 
+const UINT8 KeccakF_RotationConstants[25] =
 {
      1,  3,  6, 10, 15, 21, 28, 36, 45, 55,  2, 14, 27, 41, 56,  8, 25, 43, 62, 18, 39, 61, 20, 44
 };
 
-const UINT8 KeccakF_PiLane[25] = 
+const UINT8 KeccakF_PiLane[25] =
 {
-    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1 
+    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1
 };
 
 #if    defined(DIVISION_INSTRUCTION)
 #define MOD5(argValue)    ((argValue) % 5)
 #else
-const UINT8 KeccakF_Mod5[10] = 
+const UINT8 KeccakF_Mod5[10] =
 {
     0, 1, 2, 3, 4, 0, 1, 2, 3, 4
 };

--- a/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv6m-le-armcc.s
+++ b/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv6m-le-armcc.s
@@ -51,11 +51,11 @@ _su	equ 24
 	ldrb		r7, [$ptr, #$g]
 	eors		$result, $result, r7
 	ldrb		r7, [$ptr, #$k]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrb		r7, [$ptr, #$m]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrb		r7, [$ptr, #$s]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	MEND
 
 	MACRO
@@ -239,7 +239,7 @@ KeccakF200_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF200_StateXORLanes
 KeccakF200_StateXORLanes   PROC
@@ -288,7 +288,7 @@ KeccakF200_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes	PROC 
+KeccakF200_StateOverwriteLanes	PROC
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateOverwriteLanes_Exit
 KeccakF200_StateOverwriteLanes_Loop
@@ -327,7 +327,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes	PROC 
+KeccakF200_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	cmp		r1, #0
 	beq		KeccakF200_StateOverwriteWithZeroes_Exit

--- a/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv6m-le-gcc.s
+++ b/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv6m-le-gcc.s
@@ -50,11 +50,11 @@
 	ldrb		r7, [\ptr, #\g]
 	eors		\result, \result, r7
 	ldrb		r7, [\ptr, #\k]
-	eors		\result, \result, r7				
+	eors		\result, \result, r7
 	ldrb		r7, [\ptr, #\m]
-	eors		\result, \result, r7				
+	eors		\result, \result, r7
 	ldrb		r7, [\ptr, #\s]
-	eors		\result, \result, r7				
+	eors		\result, \result, r7
 	.endm
 
 .macro	xorrol 		b, yy, rr
@@ -191,7 +191,7 @@
 @//
 .align 8
 .global   KeccakF200_Initialize
-KeccakF200_Initialize:  
+KeccakF200_Initialize:
 	bx		lr
 
 
@@ -201,7 +201,7 @@ KeccakF200_Initialize:
 @//
 .align 8
 .global   KeccakF200_StateInitialize
-KeccakF200_StateInitialize:  
+KeccakF200_StateInitialize:
 	movs	r1, #0
 	movs	r2, #0
 	movs	r3, #0
@@ -217,7 +217,7 @@ KeccakF200_StateInitialize:
 @//
 .align 8
 .global   KeccakF200_StateComplementBit
-KeccakF200_StateComplementBit:  
+KeccakF200_StateComplementBit:
 	lsrs	r2, r1, #3
 	add		r0, r2
 	ldrb	r2, [r0]
@@ -233,10 +233,10 @@ KeccakF200_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF200_StateXORLanes
-KeccakF200_StateXORLanes:  
+KeccakF200_StateXORLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateXORLanes_Exit
 	push	{r4-r5}
@@ -258,7 +258,7 @@ KeccakF200_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateXORBytesInLane
-KeccakF200_StateXORBytesInLane:  
+KeccakF200_StateXORBytesInLane:
 	push	{r4,lr}
 	ldr		r4, [sp, #8]
 	subs	r4, r4, #1
@@ -282,7 +282,7 @@ KeccakF200_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes: 
+KeccakF200_StateOverwriteLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateOverwriteLanes_Exit
 KeccakF200_StateOverwriteLanes_Loop:
@@ -321,7 +321,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes: 
+KeccakF200_StateOverwriteWithZeroes:
 	movs	r3, #0
 	cmp		r1, #0
 	beq		KeccakF200_StateOverwriteWithZeroes_Exit
@@ -339,7 +339,7 @@ KeccakF200_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractLanes
-KeccakF200_StateExtractLanes:  
+KeccakF200_StateExtractLanes:
 	subs	r2, r2, #1
 	bcc		KeccakF200_StateExtractLanes_Exit
 KeccakF200_StateExtractLanes_Loop:
@@ -357,7 +357,7 @@ KeccakF200_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractBytesInLane
-KeccakF200_StateExtractBytesInLane:  
+KeccakF200_StateExtractBytesInLane:
 	add		r0, r0, r1
 	add		r0, r0, r3
 	ldr		r1, [sp]
@@ -423,7 +423,7 @@ KeccakF200_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakP200_StatePermute
-KeccakP200_StatePermute:  
+KeccakP200_StatePermute:
 	push	{ r4 - r6, lr }
 	mov		r2, r8
 	mov		r3, r9

--- a/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv7m-le-armcc.s
+++ b/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv7m-le-armcc.s
@@ -151,7 +151,7 @@ KeccakF200_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF200_StateXORLanes
 KeccakF200_StateXORLanes   PROC
@@ -207,7 +207,7 @@ KeccakF200_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes	PROC 
+KeccakF200_StateOverwriteLanes	PROC
 	cbz		r2, KeccakF200_StateOverwriteLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateOverwriteLanes_Loop8
@@ -254,7 +254,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes	PROC 
+KeccakF200_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF200_StateOverwriteWithZeroes_Bytes
@@ -458,7 +458,7 @@ KeccakP200_StatePermute_RoundLoop
 	RhoPi	4, r9, _a, r8, _o		; _ga, _bo	 5 <  3
 	RhoPi	5, r8, _o, r11, _o		; _bo, _mo	 3 < 18
 	RhoPi	7, r11, _o, r11, _i		; _mo, _mi	18 < 17
-	RhoPi	2, r11, _i, r10, _e		; _mi, _ke	17 < 11	
+	RhoPi	2, r11, _i, r10, _e		; _mi, _ke	17 < 11
 	RhoPi	6, r10, _e, r9, _i		; _ke, _gi	11 <  7
 	RhoPi	3, r9, _i, r10, _a		; _gi, _ka	 7 < 10
 	RhoPi	1, r10, _a, r3,      0		; _ka, _be  10 < 1

--- a/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv7m-le-gcc.s
+++ b/SnP/KeccakP-200/OptimizedAsmARM/KeccakP-200-armv7m-le-gcc.s
@@ -109,7 +109,7 @@
 @//
 .align 8
 .global   KeccakF200_Initialize
-KeccakF200_Initialize:  
+KeccakF200_Initialize:
 	bx		lr
 
 
@@ -119,7 +119,7 @@ KeccakF200_Initialize:
 @//
 .align 8
 .global   KeccakF200_StateInitialize
-KeccakF200_StateInitialize:  
+KeccakF200_StateInitialize:
 	movs	r1, #0
 	movs	r2, #0
 	movs	r3, #0
@@ -135,7 +135,7 @@ KeccakF200_StateInitialize:
 @//
 .align 8
 .global   KeccakF200_StateComplementBit
-KeccakF200_StateComplementBit:  
+KeccakF200_StateComplementBit:
 	add		r0, r1, LSR #3
 	ldrb	r2, [r0]
 	and		r1, r1, #7
@@ -149,10 +149,10 @@ KeccakF200_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF200_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF200_StateXORLanes
-KeccakF200_StateXORLanes:  
+KeccakF200_StateXORLanes:
 	cbz		r2, KeccakF200_StateXORLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateXORLanes_Loop8
@@ -182,7 +182,7 @@ KeccakF200_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateXORBytesInLane
-KeccakF200_StateXORBytesInLane:  
+KeccakF200_StateXORBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF200_StateXORBytesInLane_Exit
@@ -205,7 +205,7 @@ KeccakF200_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteLanes
-KeccakF200_StateOverwriteLanes: 
+KeccakF200_StateOverwriteLanes:
 	cbz		r2, KeccakF200_StateOverwriteLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateOverwriteLanes_Loop8
@@ -252,7 +252,7 @@ KeccakF200_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF200_StateOverwriteWithZeroes
-KeccakF200_StateOverwriteWithZeroes: 
+KeccakF200_StateOverwriteWithZeroes:
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF200_StateOverwriteWithZeroes_Bytes
@@ -277,7 +277,7 @@ KeccakF200_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractLanes
-KeccakF200_StateExtractLanes:  
+KeccakF200_StateExtractLanes:
 	cbz		r2, KeccakF200_StateExtractLanes_Exit
 	subs	r3, r2, #4
 	bcc		KeccakF200_StateExtractLanes_Loop8
@@ -303,7 +303,7 @@ KeccakF200_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF200_StateExtractBytesInLane
-KeccakF200_StateExtractBytesInLane:  
+KeccakF200_StateExtractBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF200_StateExtractBytesInLane_Exit
@@ -377,7 +377,7 @@ KeccakF200_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakP200_StatePermute
-KeccakP200_StatePermute:  
+KeccakP200_StatePermute:
 	push		{r4-r12,lr}
 	adr			lr, KeccakP200_StatePermute_RoundConstants+18
 	sub			lr, lr, r1
@@ -456,7 +456,7 @@ KeccakP200_StatePermute_RoundLoop:
 	RhoPi	4, r9, _a, r8, _o		@ _ga, _bo	 5 <  3
 	RhoPi	5, r8, _o, r11, _o		@ _bo, _mo	 3 < 18
 	RhoPi	7, r11, _o, r11, _i		@ _mo, _mi	18 < 17
-	RhoPi	2, r11, _i, r10, _e		@ _mi, _ke	17 < 11	
+	RhoPi	2, r11, _i, r10, _e		@ _mi, _ke	17 < 11
 	RhoPi	6, r10, _e, r9, _i		@ _ke, _gi	11 <  7
 	RhoPi	3, r9, _i, r10, _a		@ _gi, _ka	 7 < 10
 	RhoPi	1, r10, _a, r3,      0		@ _ka, _be  10 < 1

--- a/SnP/KeccakP-200/OptimizedAsmAVR8/KeccakP-200-avr8-fast.s
+++ b/SnP/KeccakP-200/OptimizedAsmAVR8/KeccakP-200-avr8-fast.s
@@ -622,7 +622,7 @@ KeccakP200_StatePermute_Done:
     ret
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv6m-le-armcc.s
+++ b/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv6m-le-armcc.s
@@ -51,11 +51,11 @@ _su		equ 24*2
 	ldrh		r7, [$ptr, #$g]
 	eors		$result, $result, r7
 	ldrh		r7, [$ptr, #$k]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrh		r7, [$ptr, #$m]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	ldrh		r7, [$ptr, #$s]
-	eors		$result, $result, r7				
+	eors		$result, $result, r7
 	MEND
 
 	MACRO
@@ -247,7 +247,7 @@ KeccakF400_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF400_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF400_StateXORLanes
 KeccakF400_StateXORLanes   PROC
@@ -310,7 +310,7 @@ KeccakF400_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteLanes
-KeccakF400_StateOverwriteLanes	PROC 
+KeccakF400_StateOverwriteLanes	PROC
 	subs	r2, r2, #1
 	bcc		KeccakF400_StateOverwriteLanes_Exit
 	lsls	r2, r2, #1
@@ -361,7 +361,7 @@ KeccakF400_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteWithZeroes
-KeccakF400_StateOverwriteWithZeroes	PROC 
+KeccakF400_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	cmp		r1, #0
 	beq		KeccakF400_StateOverwriteWithZeroes_Exit

--- a/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-armcc.s
+++ b/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-armcc.s
@@ -53,10 +53,10 @@ _su		equ 24*2
 	ldrh		r6, [$ptr, #$g]
 	eor			$result, $result, $rs
 	ldrh		$rs, [$ptr, #$k]
-	eor			$result, $result, r6				
+	eor			$result, $result, r6
 	ldrh		r6, [$ptr, #$m]
 	eor			$result, $result, $rs
-	eor			$result, $result, r6				
+	eor			$result, $result, r6
 	MEND
 
 	MACRO
@@ -66,10 +66,10 @@ _su		equ 24*2
 	ldr			r6, [$ptr, #$g]
 	eor			$resultL, $resultL, $rsL
 	ldr			$rsL, [$ptr, #$k]
-	eor			$resultL, $resultL, r6				
+	eor			$resultL, $resultL, r6
 	ldr			r6, [$ptr, #$m]
 	eor			$resultL, $resultL, $rsL
-	eor			$resultL, $resultL, r6				
+	eor			$resultL, $resultL, r6
 	lsr			$resultH, $resultL, #16
 	uxth 		$resultL, $resultL
 	MEND
@@ -256,7 +256,7 @@ KeccakF400_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF400_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF400_StateXORLanes
 KeccakF400_StateXORLanes   PROC
@@ -310,7 +310,7 @@ KeccakF400_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteLanes
-KeccakF400_StateOverwriteLanes	PROC 
+KeccakF400_StateOverwriteLanes	PROC
 	cbz		r2, KeccakF400_StateOverwriteLanes_Exit
 KeccakF400_StateOverwriteLanes_Loop
 	ldrh	r3, [r1], #2
@@ -347,7 +347,7 @@ KeccakF400_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF400_StateOverwriteWithZeroes
-KeccakF400_StateOverwriteWithZeroes	PROC 
+KeccakF400_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF400_StateOverwriteWithZeroes_Bytes
@@ -482,11 +482,11 @@ KeccakP400_StatePermute   PROC
     xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 	b			KeccakF400_StatePermute_RoundOdd
 KeccakF400_StatePermuteIntern
-    ldrh		r9, [r0, #_sa] 
-    ldrh		r10, [r0, #_se] 
-    ldrh		r11, [r0, #_si] 
-    ldrh		lr, [r0, #_su] 
-    ldrh		r12, [r0, #_so] 
+    ldrh		r9, [r0, #_sa]
+    ldrh		r10, [r0, #_se]
+    ldrh		r11, [r0, #_si]
+    ldrh		lr, [r0, #_su]
+    ldrh		r12, [r0, #_so]
 	mov			r5, lr
     xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakF400_StatePermute_RoundLoop

--- a/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-gcc.s
+++ b/SnP/KeccakP-400/OptimizedAsmARM/KeccakP-400-armv7m-le-gcc.s
@@ -52,10 +52,10 @@
 	ldrh		r6, [\ptr, #\g]
 	eor			\result, \result, \rs
 	ldrh		\rs, [\ptr, #\k]
-	eor			\result, \result, r6				
+	eor			\result, \result, r6
 	ldrh		r6, [\ptr, #\m]
 	eor			\result, \result, \rs
-	eor			\result, \result, r6				
+	eor			\result, \result, r6
 	.endm
 
 .macro	xor5D		resultL,resultH,ptr,b,g,k,m,rsL,rsH
@@ -64,10 +64,10 @@
 	ldr			r6, [\ptr, #\g]
 	eor			\resultL, \resultL, \rsL
 	ldr			\rsL, [\ptr, #\k]
-	eor			\resultL, \resultL, r6				
+	eor			\resultL, \resultL, r6
 	ldr			r6, [\ptr, #\m]
 	eor			\resultL, \resultL, \rsL
-	eor			\resultL, \resultL, r6				
+	eor			\resultL, \resultL, r6
 	lsr			\resultH, \resultL, #16
 	uxth 		\resultL, \resultL
 	.endm
@@ -207,7 +207,7 @@
 @//
 .align 8
 .global   KeccakF400_Initialize
-KeccakF400_Initialize:  
+KeccakF400_Initialize:
 	bx		lr
 
 
@@ -217,7 +217,7 @@ KeccakF400_Initialize:
 @//
 .align 8
 .global   KeccakF400_StateInitialize
-KeccakF400_StateInitialize:  
+KeccakF400_StateInitialize:
 	movs	r1, #0
 	movs	r2, #0
 	movs	r3, #0
@@ -235,7 +235,7 @@ KeccakF400_StateInitialize:
 @//
 .align 8
 .global   KeccakF400_StateComplementBit
-KeccakF400_StateComplementBit:  
+KeccakF400_StateComplementBit:
 	add		r0, r1, LSR #3
 	ldrb	r2, [r0]
 	and		r1, r1, #7
@@ -249,10 +249,10 @@ KeccakF400_StateComplementBit:
 @//----------------------------------------------------------------------------
 @//
 @// void KeccakF400_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-@// 
+@//
 .align 8
 .global   KeccakF400_StateXORLanes
-KeccakF400_StateXORLanes:  
+KeccakF400_StateXORLanes:
 	cbz		r2, KeccakF400_StateXORLanes_Exit
 	subs	r3, r2, #2
 	bcc		KeccakF400_StateXORLanes_1Lane
@@ -280,7 +280,7 @@ KeccakF400_StateXORLanes_Exit:
 @//
 .align 8
 .global   KeccakF400_StateXORBytesInLane
-KeccakF400_StateXORBytesInLane:  
+KeccakF400_StateXORBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF400_StateXORBytesInLane_Exit
@@ -303,7 +303,7 @@ KeccakF400_StateXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF400_StateOverwriteLanes
-KeccakF400_StateOverwriteLanes: 
+KeccakF400_StateOverwriteLanes:
 	cbz		r2, KeccakF400_StateOverwriteLanes_Exit
 KeccakF400_StateOverwriteLanes_Loop:
 	ldrh	r3, [r1], #2
@@ -340,7 +340,7 @@ KeccakF400_StateOverwriteBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakF400_StateOverwriteWithZeroes
-KeccakF400_StateOverwriteWithZeroes: 
+KeccakF400_StateOverwriteWithZeroes:
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF400_StateOverwriteWithZeroes_Bytes
@@ -365,7 +365,7 @@ KeccakF400_StateOverwriteWithZeroes_Exit:
 @//
 .align 8
 .global   KeccakF400_StateExtractLanes
-KeccakF400_StateExtractLanes:  
+KeccakF400_StateExtractLanes:
 	cbz		r2, KeccakF400_StateExtractLanes_Exit
 	subs	r3, r2, #2
 	bcc		KeccakF400_StateExtractLanes_1Lane
@@ -389,7 +389,7 @@ KeccakF400_StateExtractLanes_Exit:
 @//
 .align 8
 .global   KeccakF400_StateExtractBytesInLane
-KeccakF400_StateExtractBytesInLane:  
+KeccakF400_StateExtractBytesInLane:
 	ldr		r12, [sp]
 	cmp		r12, #0
 	beq		KeccakF400_StateExtractBytesInLane_Exit
@@ -452,7 +452,7 @@ KeccakF400_StateExtractAndXORBytesInLane_Exit:
 @//
 .align 8
 .global   KeccakP400_StatePermute
-KeccakP400_StatePermute:  
+KeccakP400_StatePermute:
 	push		{r4-r12,lr}
 	sub			sp, sp, #2*25+6
 	adr			r8, KeccakP400_StatePermute_RoundConstants
@@ -475,11 +475,11 @@ KeccakP400_StatePermute:
     xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 	b			KeccakF400_StatePermute_RoundOdd
 KeccakF400_StatePermuteIntern:
-    ldrh		r9, [r0, #_sa] 
-    ldrh		r10, [r0, #_se] 
-    ldrh		r11, [r0, #_si] 
-    ldrh		lr, [r0, #_su] 
-    ldrh		r12, [r0, #_so] 
+    ldrh		r9, [r0, #_sa]
+    ldrh		r10, [r0, #_se]
+    ldrh		r11, [r0, #_si]
+    ldrh		lr, [r0, #_su]
+    ldrh		r12, [r0, #_so]
 	mov			r5, lr
     xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakF400_StatePermute_RoundLoop:

--- a/SnP/KeccakP-400/OptimizedAsmAVR8/KeccakP-400-avr8-fast.s
+++ b/SnP/KeccakP-400/OptimizedAsmAVR8/KeccakP-400-avr8-fast.s
@@ -688,7 +688,7 @@ rotate16_1bit_right:
     #undef  pRound
 
     #undef  rpState
-    #undef  zero    
+    #undef  zero
     #undef  rX
     #undef  rY
     #undef  rZ

--- a/SnP/KeccakP-800-12/Compact/KeccakP-800-12-compact.c
+++ b/SnP/KeccakP-800-12/Compact/KeccakP-800-12-compact.c
@@ -47,20 +47,20 @@ typedef UINT32 tKeccakLane;
 
 #define    cKeccakNumberOfRounds    22
 
-const UINT8 KeccakF_RotationConstants[25] = 
+const UINT8 KeccakF_RotationConstants[25] =
 {
      1,  3,  6, 10, 15, 21, 28, 36, 45, 55,  2, 14, 27, 41, 56,  8, 25, 43, 62, 18, 39, 61, 20, 44
 };
 
-const UINT8 KeccakF_PiLane[25] = 
+const UINT8 KeccakF_PiLane[25] =
 {
-    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1 
+    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4, 15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1
 };
 
 #if    defined(DIVISION_INSTRUCTION)
 #define MOD5(argValue)    ((argValue) % 5)
 #else
-const UINT8 KeccakF_Mod5[10] = 
+const UINT8 KeccakF_Mod5[10] =
 {
     0, 1, 2, 3, 4, 0, 1, 2, 3, 4
 };
@@ -198,7 +198,7 @@ void KeccakP800_12_StatePermute(void *argState)
 	nr = 12;
 	for ( y = (tSmallUInt)(cKeccakNumberOfRounds - 12); y != 0; --y )
 	{
-        for( x = 1; x < 128; x <<= 1 ) 
+        for( x = 1; x < 128; x <<= 1 )
         {
             if ((LFSRstate & 0x80) != 0)
                 // Primitive polynomial over GF(2): x^8+x^6+x^5+x^4+1
@@ -256,7 +256,7 @@ void KeccakP800_12_StatePermute(void *argState)
 
         //    Iota
         temp = 0;
-        for( x = 1; x < 128; x <<= 1 ) 
+        for( x = 1; x < 128; x <<= 1 )
         {
             if ( x <= (sizeof(tKeccakLane)*8) )
                 temp ^= (tKeccakLane)(LFSRstate & 1) << (x - 1);

--- a/SnP/KeccakP-800-12/OptimizedAsmARM/KeccakP-800-12-armv6m-le-armcc.s
+++ b/SnP/KeccakP-800-12/OptimizedAsmARM/KeccakP-800-12-armv6m-le-armcc.s
@@ -53,11 +53,11 @@ _su		equ 24*4
 	ldr			r6, [$ptr, #$g]
 	eors		$result, $result, r6
 	ldr			r6, [$ptr, #$k]
-	eors		$result, $result, r6				
+	eors		$result, $result, r6
 	ldr			r6, [$ptr, #$m]
-	eors		$result, $result, r6				
+	eors		$result, $result, r6
 	ldr			r6, [$ptr, #$s]
-	eors		$result, $result, r6				
+	eors		$result, $result, r6
 	MEND
 
 	MACRO
@@ -249,7 +249,7 @@ KeccakF800_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF800_StateXORLanes
 KeccakF800_StateXORLanes   PROC
@@ -325,7 +325,7 @@ KeccakF800_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes	PROC 
+KeccakF800_StateOverwriteLanes	PROC
 	subs	r2, r2, #1
 	bcc		KeccakF800_StateOverwriteLanes_Exit
 	lsls	r2, r2, #2
@@ -376,7 +376,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes	PROC 
+KeccakF800_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -557,7 +557,7 @@ KeccakP800_12_StatePermute_RoundConstants
 	dcd			0x0000800a
 	dcd			0x8000000a
 	dcd			0x80008081
-	dcd			0x00008080 
+	dcd			0x00008080
 	dcd			0xFF			;//terminator
 
 ;//----------------------------------------------------------------------------
@@ -595,7 +595,7 @@ KeccakP800_StatePermute_Done
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP800_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -670,7 +670,7 @@ KeccakP800_12_SnP_FBWL_Absorb_TrailingBits
 KeccakP800_12_SnP_FBWL_Absorb_Exit
 	mov		r0, r4						; return processed
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -732,7 +732,7 @@ KeccakP800_12_SnP_FBWL_Squeeze_CheckLoop
 KeccakP800_12_SnP_FBWL_Squeeze_Exit
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -756,7 +756,7 @@ KeccakP800_12_SnP_FBWL_Squeeze_Unaligned_LoopLane
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP800_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -847,7 +847,7 @@ KeccakP800_12_SnP_FBWL_Wrap_TrailingBits
 KeccakP800_12_SnP_FBWL_Wrap_Exit
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4
@@ -858,7 +858,7 @@ KeccakP800_12_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP800_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN
@@ -949,7 +949,7 @@ KeccakP800_12_SnP_FBWL_Unwrap_TrailingBits
 KeccakP800_12_SnP_FBWL_Unwrap_Exit
 	mov		r0, r4
 	pop		{ r4 - r5 }
-	mov		r11, r4 
+	mov		r11, r4
 	mov		r12, r5
 	pop		{ r4 - r7 }
 	mov		r8, r4

--- a/SnP/KeccakP-800-12/OptimizedAsmARM/KeccakP-800-12-armv7a-le-armcc.s
+++ b/SnP/KeccakP-800-12/OptimizedAsmARM/KeccakP-800-12-armv7a-le-armcc.s
@@ -253,7 +253,7 @@ KeccakF800_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 	ALIGN
 	EXPORT  KeccakF800_StateXORLanes
 KeccakF800_StateXORLanes   PROC
@@ -319,7 +319,7 @@ KeccakF800_StateXORBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes	PROC 
+KeccakF800_StateOverwriteLanes	PROC
 	subs	r2, r2, #8
 	bcc		KeccakF800_StateOverwriteLanes_LessThan8Lanes
 	push	{ r4 - r5 }
@@ -383,7 +383,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit
 ;//
 	ALIGN
 	EXPORT  KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes	PROC 
+KeccakF800_StateOverwriteWithZeroes	PROC
 	movs	r3, #0
 	lsrs	r2, r1, #2
 	beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -544,7 +544,7 @@ KeccakP800_12_StatePermute_RoundConstantsWithTerminator
 	dcd			0x0000800a
 	dcd			0x8000000a
 	dcd			0x80008081
-	dcd			0x00008080 
+	dcd			0x00008080
 	dcd			0			;//terminator
 
 ;//----------------------------------------------------------------------------
@@ -564,10 +564,10 @@ KeccakP800_12_StatePermute   PROC
 	mov			r6, r12
 	eor			r7, r7, r12
 	ldr			r12, [r0, #_ku]
-	eor			r7, r7, r1				
+	eor			r7, r7, r1
 	ldr			r1, [r0, #_mu]
 	eor			r7, r7, r12
-	eor			r7, r7, r1				
+	eor			r7, r7, r1
 KeccakF800_StatePermute_RoundLoop
 	KeccakRound	sp, r0
 	KeccakRound	r0, sp
@@ -580,7 +580,7 @@ KeccakF800_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP800_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -684,7 +684,7 @@ KeccakP800_12_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP800_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -748,7 +748,7 @@ KeccakP800_12_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP800_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN

--- a/SnP/KeccakP-800-12/OptimizedAsmARM/KeccakP-800-12-armv7m-le-armcc.s
+++ b/SnP/KeccakP-800-12/OptimizedAsmARM/KeccakP-800-12-armv7m-le-armcc.s
@@ -160,10 +160,10 @@ _su		equ 24*4
 		ldr			r6, [$ptr, #$g]
 		eor			$result, $result, $rs
 		ldr			$rs, [$ptr, #$k]
-		eor			$result, $result, r6				
+		eor			$result, $result, r6
 		ldr			r6, [$ptr, #$m]
 		eor			$result, $result, $rs
-		eor			$result, $result, r6				
+		eor			$result, $result, r6
 		MEND
 
 		MACRO
@@ -246,7 +246,7 @@ KeccakF800_StateComplementBit   PROC
 ;//----------------------------------------------------------------------------
 ;//
 ;// void KeccakF800_StateXORLanes(void *state, const unsigned char *data, unsigned int laneCount)
-;// 
+;//
 		ALIGN
 		EXPORT  KeccakF800_StateXORLanes
 KeccakF800_StateXORLanes   PROC
@@ -311,7 +311,7 @@ KeccakF800_StateXORBytesInLane_Exit
 ;//
 		ALIGN
 		EXPORT  KeccakF800_StateOverwriteLanes
-KeccakF800_StateOverwriteLanes	PROC 
+KeccakF800_StateOverwriteLanes	PROC
 		subs	r2, r2, #8
 		bcc		KeccakF800_StateOverwriteLanes_LessThan8Lanes
 		push	{ r4 - r5 }
@@ -375,7 +375,7 @@ KeccakF800_StateOverwriteBytesInLane_Exit
 ;//
 		ALIGN
 		EXPORT  KeccakF800_StateOverwriteWithZeroes
-KeccakF800_StateOverwriteWithZeroes	PROC 
+KeccakF800_StateOverwriteWithZeroes	PROC
 		movs	r3, #0
 		lsrs	r2, r1, #2
 		beq		KeccakF800_StateOverwriteWithZeroes_Bytes
@@ -536,7 +536,7 @@ KeccakP800_12_StatePermute_RoundConstantsWithTerminator
 		dcd			0x0000800a
 		dcd			0x8000000a
 		dcd			0x80008081
-		dcd			0x00008080 
+		dcd			0x00008080
 		dcd			0			;//terminator
 
 ;//----------------------------------------------------------------------------
@@ -549,11 +549,11 @@ KeccakP800_12_StatePermute   PROC
 		push		{r4-r12,lr}
 		sub			sp, sp, #4*25
 		adr			r8, KeccakP800_12_StatePermute_RoundConstantsWithTerminator
-	    ldr			r9, [r0, #_sa] 
-	    ldr			r10, [r0, #_se] 
-	    ldr			r11, [r0, #_si] 
-	    ldr			lr, [r0, #_su] 
-	    ldr			r12, [r0, #_so] 
+	    ldr			r9, [r0, #_sa]
+	    ldr			r10, [r0, #_se]
+	    ldr			r11, [r0, #_si]
+	    ldr			lr, [r0, #_su]
+	    ldr			r12, [r0, #_so]
 		mov			r5, lr
 	    xor5		r7, r0, _bu, _gu, _ku, _mu, lr
 KeccakP800_StatePermute_RoundLoop
@@ -567,7 +567,7 @@ KeccakP800_StatePermute_RoundLoop
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data, 
+; size_t KeccakP800_12_SnP_FBWL_Absorb(	void *state, unsigned int laneCount, unsigned char *data,
 ;										size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -671,7 +671,7 @@ KeccakP800_12_SnP_FBWL_Squeeze_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP800_12_SnP_FBWL_Wrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits )
 ;
 	ALIGN
@@ -735,7 +735,7 @@ KeccakP800_12_SnP_FBWL_Wrap_Exit
 
 ;----------------------------------------------------------------------------
 ;
-; size_t KeccakP800_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn, 
+; size_t KeccakP800_12_SnP_FBWL_Unwrap( void *state, unsigned int laneCount, const unsigned char *dataIn,
 ;										unsigned char *dataOut, size_t dataByteLen, unsigned char trailingBits)
 ;
 	ALIGN

--- a/Tests/genKAT.c
+++ b/Tests/genKAT.c
@@ -138,7 +138,7 @@ genShortMsgHash(unsigned int rate, unsigned int capacity, unsigned char delimite
     BitSequence Squeezed[SqueezingOutputLength/8];
     Keccak_HashInstance   hash;
     FILE        *fp_in, *fp_out;
-    
+
     if ((squeezedOutputLength > SqueezingOutputLength) || (hashbitlen > SqueezingOutputLength)) {
         printf("Requested output length too long.\n");
         return KAT_HASH_ERROR;
@@ -148,13 +148,13 @@ genShortMsgHash(unsigned int rate, unsigned int capacity, unsigned char delimite
         printf("Couldn't open <ShortMsgKAT.txt> for read\n");
         return KAT_FILE_OPEN_ERROR;
     }
-    
+
     if ( (fp_out = fopen(fileName, "w")) == NULL ) {
         printf("Couldn't open <%s> for write\n", fileName);
         return KAT_FILE_OPEN_ERROR;
     }
     fprintf(fp_out, "# %s\n", description);
-    
+
     do {
         if ( FindMarker(fp_in, "Len = ") )
             fscanf(fp_in, "%d", &msglen);
@@ -181,10 +181,10 @@ genShortMsgHash(unsigned int rate, unsigned int capacity, unsigned char delimite
         }
     } while ( 1 );
     printf("finished ShortMsgKAT for <%s>\n", fileName);
-    
+
     fclose(fp_in);
     fclose(fp_out);
-    
+
     return KAT_SUCCESS;
 }
 
@@ -255,7 +255,7 @@ ReadHex(FILE *infile, BitSequence *A, int Length, char *str)
                 ich = ch - 'A' + 10;
             else if ( (ch >= 'a') && (ch <= 'f') )
                 ich = ch - 'a' + 10;
-            
+
             for ( i=0; i<Length-1; i++ )
                 A[i] = (A[i] << 4) | (A[i+1] >> 4);
             A[Length-1] = (A[Length-1] << 4) | ich;

--- a/Tests/main.c
+++ b/Tests/main.c
@@ -234,7 +234,7 @@ void displayDuplexIntermediateValuesOne(FILE *f, unsigned int rate, unsigned int
 
     Keccak_DuplexInitialize(&duplex, rate, capacity);
     displayStateAsBytes(1, "Initial state", duplex.state);
-    
+
     for(i=0; i<=rate+120; i+=123) {
         inBitLen = i;
         if (inBitLen > (rate-2)) inBitLen = rate-2;

--- a/Tests/testKetje.c
+++ b/Tests/testKetje.c
@@ -40,7 +40,7 @@ void generateSimpleRawMaterial(unsigned char* data, unsigned int length, unsigne
     unsigned int i;
 
     for( i=0; i<length; i++) {
-        unsigned int iRolled = i*seed1; 
+        unsigned int iRolled = i*seed1;
         unsigned char byte = (iRolled+length+seed2)%0xFF;
         data[i] = byte;
     }
@@ -48,7 +48,7 @@ void generateSimpleRawMaterial(unsigned char* data, unsigned int length, unsigne
 
 void errorIfNotZero( unsigned int result )
 {
-	if ( result != 0 ) 
+	if ( result != 0 )
 	{
 		printf( "\n\nError\n" );
 		exit( result );
@@ -82,7 +82,7 @@ void testKetje()
 #ifdef OUTPUT
     assert(f != NULL);
 #endif
-	
+
 	Ketje_Initialize(&checksum, 0, 0, 0, 0);
 
     for( keySizeInBits=keyMaxSizeInBits; keySizeInBits >=96; keySizeInBits -= (keySizeInBits > 200) ? 100 : ((keySizeInBits > 128) ? 27 : 16))
@@ -143,7 +143,7 @@ void testKetje()
 					//printf("ADlen %u, Mlen %u\n", ADlen, Mlen);
                     generateSimpleRawMaterial(associatedData, ADlen, 0x34+Mlen, 3);
                     generateSimpleRawMaterial(plaintext, Mlen, 0x45+ADlen, 4);
-                            
+
                     {
                         unsigned int split = myMin(ADlen/4, (unsigned int)200);
 						unsigned int i;
@@ -155,14 +155,14 @@ void testKetje()
                             errorIfNotZero( Ketje_FeedAssociatedData( &ketje1, associatedData+split, ADlen-split) );
                     }
                     errorIfNotZero( Ketje_FeedAssociatedData( &ketje2, associatedData, ADlen) );
-                            
+
                     {
                         unsigned int split = Mlen/3;
                         memcpy(ciphertext, plaintext, split);
                         errorIfNotZero( Ketje_WrapPlaintext( &ketje1, ciphertext, ciphertext, split) ); // in place
                         errorIfNotZero( Ketje_WrapPlaintext( &ketje1, plaintext+split, ciphertext+split, Mlen-split) );
                     }
-                            
+
                     {
                         unsigned int split = Mlen/3*2;
                         memcpy(plaintextPrime, ciphertext, split);

--- a/Tests/testPlSnP.c
+++ b/Tests/testPlSnP.c
@@ -125,7 +125,7 @@ void testPlSnP(void)
     // Testing PlSnP_OverwriteWithZeroes()
     {
         unsigned byteCount, instanceIndex;
-        
+
         for(instanceIndex=0; instanceIndex<PlSnP_P; instanceIndex++)
         for(byteCount=0; byteCount<=SnP_width/8; byteCount++) {
             PlSnP_PermuteAll(stateTest);
@@ -355,7 +355,7 @@ void testPlSnP(void)
         unsigned int i;
         FILE *f;
         char fileName[100];
-    
+
         PlSnP_ExtractLanesAll(stateAccumulated, buffer, SnP_laneCount, SnP_laneCount);
 #ifdef Keyak
         sprintf(fileName, "PlSnP/Parallel%dKeccakP-%d-12.txt", PlSnP_P, SnP_width);

--- a/Tests/testSnP.c
+++ b/Tests/testSnP.c
@@ -89,7 +89,7 @@ void testSnP(void)
     // Testing SnP_OverwriteWithZeroes()
     {
         unsigned byteCount;
-        
+
         for(byteCount=0; byteCount<=SnP_width/8; byteCount++) {
             SnP_Permute(stateTest);
             SnP_OverwriteWithZeroes(stateTest, byteCount);
@@ -101,7 +101,7 @@ void testSnP(void)
     // Testing SnP_ComplementBit()
     {
         unsigned bitPosition;
-        
+
         for(bitPosition=0; bitPosition<SnP_width; bitPosition += (bitPosition < 128) ? 1 : 19) {
             SnP_ComplementBit(stateTest, bitPosition);
             accumulateState(stateAccumulated, stateTest);
@@ -300,7 +300,7 @@ void testSnP(void)
         unsigned int i;
         FILE *f;
         char fileName[100];
-    
+
         SnP_ExtractBytes(stateAccumulated, buffer, 0, SnP_width/8);
 #ifdef Keyak
         sprintf(fileName, "SnP/KeccakP-%d-12.txt", SnP_width);


### PR DESCRIPTION
Removed all whitespaces in source code, because some editors trim them when saving files. This causes many file diffs when only one line was changed.
