### PR TITLE
Initial continuous integration setup using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+
+sudo: required
+
+compiler:
+  - clang
+  - gcc
+
+os:
+  - linux
+  - osx
+
+arch:
+  - amd64
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -qq update && sudo apt-get install xsltproc; fi
+
+script:
+  - make generic64/KeccakTests && ./bin/generic64/KeccakTests --all

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](http://img.shields.io/travis/XKCP/XKCP.svg)](https://travis-ci.org/XKCP/XKCP)
+
 # What is the XKCP?
 
 The **eXtended Keccak Code Package** (or the **Xoodoo and Keccak Code Package**, in both cases abbreviated as **XKCP**) gathers different free and open-source implementations of the [Keccak sponge function family](https://keccak.team/keccak.html)


### PR DESCRIPTION
Hi,

This commit includes the initial continuous integration setup for XKPC using Travis. For now, the idea is just to put it in place and gradually bring new changes and expand it to new operational systems and architectures.

The current configuration includes compilation with gcc, clang, on linux and osx (amd64). 

Thanks,
Hussama