### PR TITLE
Renamed enumerations of HashReturn.

### DIFF
--- a/lib/high/Keccak/FIPS202/KeccakHash.c
+++ b/lib/high/Keccak/FIPS202/KeccakHash.c
@@ -21,13 +21,13 @@ HashReturn Keccak_HashInitialize(Keccak_HashInstance *instance, unsigned int rat
     HashReturn result;
 
     if (delimitedSuffix == 0)
-        return FAIL;
+        return KECCAK_FAIL;
     result = (HashReturn)KeccakWidth1600_SpongeInitialize(&instance->sponge, rate, capacity);
-    if (result != SUCCESS)
+    if (result != KECCAK_SUCCESS)
         return result;
     instance->fixedOutputLength = hashbitlen;
     instance->delimitedSuffix = delimitedSuffix;
-    return SUCCESS;
+    return KECCAK_SUCCESS;
 }
 
 /* ---------------------------------------------------------------- */
@@ -38,7 +38,7 @@ HashReturn Keccak_HashUpdate(Keccak_HashInstance *instance, const BitSequence *d
         return (HashReturn)KeccakWidth1600_SpongeAbsorb(&instance->sponge, data, databitlen/8);
     else {
         HashReturn ret = (HashReturn)KeccakWidth1600_SpongeAbsorb(&instance->sponge, data, databitlen/8);
-        if (ret == SUCCESS) {
+        if (ret == KECCAK_SUCCESS) {
             /* The last partial byte is assumed to be aligned on the least significant bits */
             unsigned char lastByte = data[databitlen/8];
             /* Concatenate the last few bits provided here with those of the suffix */
@@ -62,7 +62,7 @@ HashReturn Keccak_HashUpdate(Keccak_HashInstance *instance, const BitSequence *d
 HashReturn Keccak_HashFinal(Keccak_HashInstance *instance, BitSequence *hashval)
 {
     HashReturn ret = (HashReturn)KeccakWidth1600_SpongeAbsorbLastFewBits(&instance->sponge, instance->delimitedSuffix);
-    if (ret == SUCCESS)
+    if (ret == KECCAK_SUCCESS)
         return (HashReturn)KeccakWidth1600_SpongeSqueeze(&instance->sponge, hashval, instance->fixedOutputLength/8);
     else
         return ret;
@@ -73,6 +73,6 @@ HashReturn Keccak_HashFinal(Keccak_HashInstance *instance, BitSequence *hashval)
 HashReturn Keccak_HashSqueeze(Keccak_HashInstance *instance, BitSequence *data, BitLength databitlen)
 {
     if ((databitlen % 8) != 0)
-        return FAIL;
+        return KECCAK_FAIL;
     return (HashReturn)KeccakWidth1600_SpongeSqueeze(&instance->sponge, data, databitlen/8);
 }

--- a/lib/high/Keccak/FIPS202/KeccakHash.h
+++ b/lib/high/Keccak/FIPS202/KeccakHash.h
@@ -26,7 +26,7 @@ typedef unsigned char BitSequence;
 typedef size_t BitLength;
 #endif
 
-typedef enum { SUCCESS = 0, FAIL = 1, BAD_HASHLEN = 2 } HashReturn;
+typedef enum { KECCAK_SUCCESS = 0, KECCAK_FAIL = 1, KECCAK_BAD_HASHLEN = 2 } HashReturn;
 
 typedef struct {
     KeccakWidth1600_SpongeInstance sponge;
@@ -47,7 +47,7 @@ typedef struct {
   *                         formatted like the @a delimitedData parameter of
   *                         the Keccak_SpongeAbsorbLastFewBits() function.
   * @pre    One must have r+c=1600 and the rate a multiple of 8 bits in this implementation.
-  * @return SUCCESS if successful, FAIL otherwise.
+  * @return KECCAK_SUCCESS if KECCAK_successful, KECCAK_FAIL otherwise.
   */
 HashReturn Keccak_HashInitialize(Keccak_HashInstance *hashInstance, unsigned int rate, unsigned int capacity, unsigned int hashbitlen, unsigned char delimitedSuffix);
 
@@ -85,7 +85,7 @@ HashReturn Keccak_HashInitialize(Keccak_HashInstance *hashInstance, unsigned int
   *                     of the last byte are ignored.
   * @param  databitLen  The number of input bits provided in the input data.
   * @pre    In the previous call to Keccak_HashUpdate(), databitlen was a multiple of 8.
-  * @return SUCCESS if successful, FAIL otherwise.
+  * @return KECCAK_SUCCESS if KECCAK_successful, KECCAK_FAIL otherwise.
   */
 HashReturn Keccak_HashUpdate(Keccak_HashInstance *hashInstance, const BitSequence *data, BitLength databitlen);
 
@@ -98,7 +98,7 @@ HashReturn Keccak_HashUpdate(Keccak_HashInstance *hashInstance, const BitSequenc
   * If @a hashbitlen was 0 in the call to Keccak_HashInitialize(), the output bits
   *     must be extracted using the Keccak_HashSqueeze() function.
   * @param  hashval     Pointer to the buffer where to store the output data.
-  * @return SUCCESS if successful, FAIL otherwise.
+  * @return KECCAK_SUCCESS if KECCAK_successful, KECCAK_FAIL otherwise.
   */
 HashReturn Keccak_HashFinal(Keccak_HashInstance *hashInstance, BitSequence *hashval);
 
@@ -109,7 +109,7 @@ HashReturn Keccak_HashFinal(Keccak_HashInstance *hashInstance, BitSequence *hash
   * @param  databitlen  The number of output bits desired (must be a multiple of 8).
   * @pre    Keccak_HashFinal() must have been already called.
   * @pre    @a databitlen is a multiple of 8.
-  * @return SUCCESS if successful, FAIL otherwise.
+  * @return KECCAK_SUCCESS if KECCAK_successful, KECCAK_FAIL otherwise.
   */
 HashReturn Keccak_HashSqueeze(Keccak_HashInstance *hashInstance, BitSequence *data, BitLength databitlen);
 

--- a/tests/UnitTests/genKAT.c
+++ b/tests/UnitTests/genKAT.c
@@ -176,7 +176,7 @@ genShortMsgHash(unsigned int rate, unsigned int capacity, unsigned char delimite
         fprintf(fp_out, "\nLen = %d\n", msglen);
         fprintBstr(fp_out, "Msg = ", Msg, msgbytelen);
 
-        if (Keccak_HashInitialize(&hash, rate, capacity, hashbitlen, delimitedSuffix) != SUCCESS) {
+        if (Keccak_HashInitialize(&hash, rate, capacity, hashbitlen, delimitedSuffix) != KECCAK_SUCCESS) {
             printf("Keccak[r=%d, c=%d] is not supported.\n", rate, capacity);
             return KAT_HASH_ERROR;
         }


### PR DESCRIPTION
This PR is trying to fix compilation errors on some embedded os by adding prefix on HashReturn enum.

`SUCCESS` and `FAIL` are commonly used as system enumerations in some real-time OSs. it caused  errors on FreeRTOS and mBed OS, like: 
```
nucleo_f746zg_debug/Keccak/lib/high/Keccak/FIPS202/KeccakHash.h:29:26: error: redeclaration of 'SUCCESS'
 typedef enum { SUCCESS = 0, FAIL = 1, BAD_HASHLEN = 2 } HashReturn;
                          ^
```