### PR TITLE
Use vpcmpeqd instead of vpcmpeqq

### DIFF
--- a/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
+++ b/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
@@ -715,7 +715,7 @@ KeccakF1600_FastLoop_Absorb_Loop21Lanes:
     vmovdqu         8(%rdx),%ymm8
 
     vmovdqa         map2(%rip), %xmm15
-    vpcmpeqq        %ymm14, %ymm14, %ymm14    
+    vpcmpeqd        %ymm14, %ymm14, %ymm14
     vpgatherdq      %ymm14, (%rdx, %xmm15, 1), %ymm9
 
     vmovdqa         mask3_21(%rip), %ymm14
@@ -897,7 +897,7 @@ KeccakP1600_12rounds_FastLoop_Absorb_Loop21Lanes:
     vmovdqu         8(%rdx),%ymm8
 
     vmovdqa         map2(%rip), %xmm15
-    vpcmpeqq        %ymm14, %ymm14, %ymm14    
+    vpcmpeqd        %ymm14, %ymm14, %ymm14
     vpgatherdq      %ymm14, (%rdx, %xmm15, 1), %ymm9
 
     vmovdqa         mask3_21(%rip), %ymm14


### PR DESCRIPTION
vpcmpeqq is not recognized as dependency-breaking instruction on
Bulldozer and Piledriver CPUs. vpcmpeqd vpcmpeqd produces the same
output register and is recognized as dependency-breaking on all CPUs
that support it (based on
https://www.agner.org/optimize/microarchitecture.pdf, 19.14)