### PR TITLE
Fix AVX2 and AVX512 builds for mingw

### DIFF
--- a/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
+++ b/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
@@ -14,6 +14,7 @@
 # (https://github.com/dot-asm/cryptogams/blob/master/x86_64/keccak1600-avx2.pl).
 # The rest of the code was written by Ronny Van Keer.
 # Adaptations for macOS by Stéphane Léon.
+# Adaptations for mingw-w64 (changes macOS too) by Jorrit Jongma.
 
 .text
 
@@ -21,12 +22,14 @@
 #
 # void KeccakP1600_Initialize(void *state);
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Initialize
 _KeccakP1600_Initialize:
 .else
 .globl  KeccakP1600_Initialize
+.ifndef no_type
 .type   KeccakP1600_Initialize,@function
+.endif
 KeccakP1600_Initialize:
 .endif
 .balign 32
@@ -39,8 +42,7 @@ KeccakP1600_Initialize:
     vmovdqu     %ymm0,5*32(%rdi)
     movq        $0,6*32(%rdi)
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Initialize,.-KeccakP1600_Initialize
 .endif
 
@@ -49,12 +51,14 @@ KeccakP1600_Initialize:
 # void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset);
 #                                %rdi                 %rsi               %rdx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_AddByte
 _KeccakP1600_AddByte:
 .else
 .globl  KeccakP1600_AddByte
+.ifndef no_type
 .type   KeccakP1600_AddByte,@function
+.endif
 KeccakP1600_AddByte:
 .endif
 .balign 32
@@ -67,8 +71,7 @@ KeccakP1600_AddByte:
     add         %rax, %rdi
     xorb        %sil, (%rdi)
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_AddByte,.-KeccakP1600_AddByte
 .endif
 
@@ -77,12 +80,14 @@ KeccakP1600_AddByte:
 # void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
 #                                %rdi                         %rsi               %rdx                 %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_AddBytes
 _KeccakP1600_AddBytes:
 .else
 .globl  KeccakP1600_AddBytes
+.ifndef no_type
 .type   KeccakP1600_AddBytes,@function
+.endif
 KeccakP1600_AddBytes:
 .endif
 .balign 32
@@ -134,8 +139,7 @@ KeccakP1600_AddBytes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_AddBytes_LastIncompleteLaneLoop
 KeccakP1600_AddBytes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_AddBytes,.-KeccakP1600_AddBytes
 .endif
 
@@ -144,12 +148,14 @@ KeccakP1600_AddBytes_Exit:
 # void KeccakP1600_OverwriteBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
 #                                       %rdi                        %rsi               %rdx                 %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_OverwriteBytes
 _KeccakP1600_OverwriteBytes:
 .else
 .globl  KeccakP1600_OverwriteBytes
+.ifndef no_type
 .type   KeccakP1600_OverwriteBytes,@function
+.endif
 KeccakP1600_OverwriteBytes:
 .endif
 .balign 32
@@ -201,8 +207,7 @@ KeccakP1600_OverwriteBytes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_OverwriteBytes_LastIncompleteLaneLoop
 KeccakP1600_OverwriteBytes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_OverwriteBytes,.-KeccakP1600_OverwriteBytes
 .endif
 
@@ -211,12 +216,14 @@ KeccakP1600_OverwriteBytes_Exit:
 # void KeccakP1600_OverwriteWithZeroes(void *state, unsigned int byteCount);
 #                                            %rdi                %rsi
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_OverwriteWithZeroes
 _KeccakP1600_OverwriteWithZeroes:
 .else
 .globl  KeccakP1600_OverwriteWithZeroes
+.ifndef no_type
 .type   KeccakP1600_OverwriteWithZeroes,@function
+.endif
 KeccakP1600_OverwriteWithZeroes:
 .endif
 .balign 32
@@ -244,8 +251,7 @@ KeccakP1600_OverwriteWithZeroes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_OverwriteWithZeroes_LastIncompleteLaneLoop
 KeccakP1600_OverwriteWithZeroes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_OverwriteWithZeroes,.-KeccakP1600_OverwriteWithZeroes
 .endif
 
@@ -254,12 +260,14 @@ KeccakP1600_OverwriteWithZeroes_Exit:
 # void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
 #                                           %rdi                  %rsi               %rdx                 %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_ExtractBytes
 _KeccakP1600_ExtractBytes:
 .else
 .globl  KeccakP1600_ExtractBytes
+.ifndef no_type
 .type   KeccakP1600_ExtractBytes,@function
+.endif
 KeccakP1600_ExtractBytes:
 .endif
 .balign 32
@@ -314,8 +322,7 @@ KeccakP1600_ExtractBytes_LastIncompleteLaneLoop:
 KeccakP1600_ExtractBytes_Exit:
     pop         %rbx
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_ExtractBytes,.-KeccakP1600_ExtractBytes
 .endif
 
@@ -324,12 +331,14 @@ KeccakP1600_ExtractBytes_Exit:
 # void KeccakP1600_ExtractAndAddBytes(const void *state, const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);
 #                                                 %rdi                        %rsi                  %rdx                 %rcx                  %r8
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_ExtractAndAddBytes
 _KeccakP1600_ExtractAndAddBytes:
 .else
 .globl  KeccakP1600_ExtractAndAddBytes
+.ifndef no_type
 .type   KeccakP1600_ExtractAndAddBytes,@function
+.endif
 KeccakP1600_ExtractAndAddBytes:
 .endif
 .balign 32
@@ -392,8 +401,7 @@ KeccakP1600_ExtractAndAddBytes_Exit:
     pop         %r10
     pop         %rbx
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_ExtractAndAddBytes,.-KeccakP1600_ExtractAndAddBytes
 .endif
 
@@ -401,8 +409,7 @@ KeccakP1600_ExtractAndAddBytes_Exit:
 #
 # internal    
 #
-.ifdef macOS
-.else
+.ifndef no_type
 .type    __KeccakF1600,@function
 .endif
 .balign 32
@@ -544,19 +551,20 @@ __KeccakF1600:
     dec         %eax
     jnz         .Loop_avx2
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   __KeccakF1600,.-__KeccakF1600
 .endif
 
 
 
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Permute_24rounds
 _KeccakP1600_Permute_24rounds:
 .else
 .globl  KeccakP1600_Permute_24rounds
+.ifndef no_type
 .type   KeccakP1600_Permute_24rounds,@function
+.endif
 KeccakP1600_Permute_24rounds:
 .endif
 .balign 32
@@ -583,17 +591,18 @@ KeccakP1600_Permute_24rounds:
     vmovdqu         %ymm6,8+32*5-96(%rdi)
     vzeroupper
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Permute_24rounds,.-KeccakP1600_Permute_24rounds
 .endif
 
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Permute_12rounds
 _KeccakP1600_Permute_12rounds:
 .else
 .globl  KeccakP1600_Permute_12rounds
+.ifndef no_type
 .type   KeccakP1600_Permute_12rounds,@function
+.endif
 KeccakP1600_Permute_12rounds:
 .endif
 .balign 32
@@ -620,17 +629,18 @@ KeccakP1600_Permute_12rounds:
     vmovdqu         %ymm6,8+32*5-96(%rdi)
     vzeroupper
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Permute_12rounds,.-KeccakP1600_Permute_12rounds
 .endif
 
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Permute_Nrounds
 _KeccakP1600_Permute_Nrounds:
 .else
 .globl  KeccakP1600_Permute_Nrounds
+.ifndef no_type
 .type   KeccakP1600_Permute_Nrounds,@function
+.endif
 KeccakP1600_Permute_Nrounds:
 .endif
 .balign 32
@@ -659,8 +669,7 @@ KeccakP1600_Permute_Nrounds:
     vmovdqu         %ymm6,8+32*5-96(%rdi)
     vzeroupper
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Permute_Nrounds,.-KeccakP1600_Permute_Nrounds
 .endif
 
@@ -669,12 +678,14 @@ KeccakP1600_Permute_Nrounds:
 # size_t KeccakF1600_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
 #                                          %rdi                %rsi                            %rdx         %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakF1600_FastLoop_Absorb
 _KeccakF1600_FastLoop_Absorb:
 .else
 .globl  KeccakF1600_FastLoop_Absorb
+.ifndef no_type
 .type   KeccakF1600_FastLoop_Absorb,@function
+.endif
 KeccakF1600_FastLoop_Absorb:
 .endif
 .balign 32
@@ -828,11 +839,15 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
     push            %rsi
     push            %rdx
     push            %rcx
-    .ifdef macOS
+.ifdef no_plt
+.ifdef add_underscore
     call            _KeccakP1600_Permute_24rounds
-    .else
+.else
+    call            KeccakP1600_Permute_24rounds
+.endif
+.else
     call            KeccakP1600_Permute_24rounds@PLT
-    .endif
+.endif
     pop             %rcx
     pop             %rdx
     pop             %rsi
@@ -840,8 +855,7 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
     cmp             %rsi, %rcx
     jae             KeccakF1600_FastLoop_Absorb_Not17Lanes
     jmp             KeccakF1600_FastLoop_Absorb_Exit
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakF1600_FastLoop_Absorb,.-KeccakF1600_FastLoop_Absorb
 .endif
 
@@ -850,12 +864,14 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
 # size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
 #                                          %rdi                %rsi                            %rdx         %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_12rounds_FastLoop_Absorb
 _KeccakP1600_12rounds_FastLoop_Absorb:
 .else
 .globl  KeccakP1600_12rounds_FastLoop_Absorb
+.ifndef no_type
 .type   KeccakP1600_12rounds_FastLoop_Absorb,@function
+.endif
 KeccakP1600_12rounds_FastLoop_Absorb:
 .endif
 .balign 32
@@ -1009,8 +1025,12 @@ KeccakP1600_12rounds_FastLoop_Absorb_LanesAddLoop:
     push            %rsi
     push            %rdx
     push            %rcx
-.ifdef macOS
+.ifdef no_plt
+.ifdef add_underscore
     call            _KeccakP1600_Permute_12rounds
+.else
+    call            KeccakP1600_Permute_12rounds
+.endif
 .else
     call            KeccakP1600_Permute_12rounds@PLT
 .endif
@@ -1021,8 +1041,7 @@ KeccakP1600_12rounds_FastLoop_Absorb_LanesAddLoop:
     cmp             %rsi, %rcx
     jae             KeccakP1600_12rounds_FastLoop_Absorb_Not17Lanes
     jmp             KeccakP1600_12rounds_FastLoop_Absorb_Exit
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
 .endif
 

--- a/lib/low/KeccakP-1600/AVX2/KeccakP-1600-SnP.h
+++ b/lib/low/KeccakP-1600/AVX2/KeccakP-1600-SnP.h
@@ -23,6 +23,12 @@ Please refer to SnP-documentation.h for more details.
 
 #include <stddef.h>
 
+#ifdef __MINGW32__
+#define FORCE_SYSV __attribute__((sysv_abi))
+#else
+#define FORCE_SYSV
+#endif
+
 #define KeccakP1600_implementation      "AVX2 optimized implementation"
 #define KeccakP1600_stateSizeInBytes    200
 #define KeccakP1600_stateAlignment      8
@@ -30,17 +36,17 @@ Please refer to SnP-documentation.h for more details.
 #define KeccakP1600_12rounds_FastLoop_supported
 
 #define KeccakP1600_StaticInitialize()
-void KeccakP1600_Initialize(void *state);
-void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset);
-void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakP1600_OverwriteBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakP1600_OverwriteWithZeroes(void *state, unsigned int byteCount);
-void KeccakP1600_Permute_Nrounds(void *state, unsigned int nrounds);
-void KeccakP1600_Permute_12rounds(void *state);
-void KeccakP1600_Permute_24rounds(void *state);
-void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakP1600_ExtractAndAddBytes(const void *state, const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);
-size_t KeccakF1600_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
-size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
+FORCE_SYSV void KeccakP1600_Initialize(void *state);
+FORCE_SYSV void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset);
+FORCE_SYSV void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
+FORCE_SYSV void KeccakP1600_OverwriteBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
+FORCE_SYSV void KeccakP1600_OverwriteWithZeroes(void *state, unsigned int byteCount);
+FORCE_SYSV void KeccakP1600_Permute_Nrounds(void *state, unsigned int nrounds);
+FORCE_SYSV void KeccakP1600_Permute_12rounds(void *state);
+FORCE_SYSV void KeccakP1600_Permute_24rounds(void *state);
+FORCE_SYSV void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
+FORCE_SYSV void KeccakP1600_ExtractAndAddBytes(const void *state, const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);
+FORCE_SYSV size_t KeccakF1600_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
+FORCE_SYSV size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
 
 #endif

--- a/lib/low/KeccakP-1600/AVX512/KeccakP-1600-AVX512.s
+++ b/lib/low/KeccakP-1600/AVX512/KeccakP-1600-AVX512.s
@@ -14,6 +14,7 @@
 # (https://github.com/dot-asm/cryptogams/blob/master/x86_64/keccak1600-avx512.pl).
 # The rest of the code was written by Ronny Van Keer.
 # Adaptations for macOS by Stéphane Léon.
+# Adaptations for mingw-w64 (changes macOS too) by Jorrit Jongma.
 
 .text
 
@@ -21,12 +22,14 @@
 #
 # void KeccakP1600_Initialize(void *state);
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Initialize
 _KeccakP1600_Initialize:
 .else
 .globl  KeccakP1600_Initialize
+.ifndef no_type
 .type   KeccakP1600_Initialize,@function
+.endif
 KeccakP1600_Initialize:
 .endif
 .balign 32
@@ -36,8 +39,7 @@ KeccakP1600_Initialize:
     vmovdqu64   %zmm0,2*64(%rdi)
     movq        $0,3*64(%rdi)
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Initialize,.-KeccakP1600_Initialize
 .endif
 
@@ -65,12 +67,14 @@ KeccakP1600_Initialize:
 # void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
 #                                %rdi                         %rsi               %rdx                 %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_AddBytes
 _KeccakP1600_AddBytes:
 .else
 .globl  KeccakP1600_AddBytes
+.ifndef no_type
 .type   KeccakP1600_AddBytes,@function
+.endif
 KeccakP1600_AddBytes:
 .endif
 .balign 32
@@ -112,8 +116,7 @@ KeccakP1600_AddBytes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_AddBytes_LastIncompleteLaneLoop
 KeccakP1600_AddBytes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_AddBytes,.-KeccakP1600_AddBytes
 .endif
 
@@ -122,12 +125,14 @@ KeccakP1600_AddBytes_Exit:
 # void KeccakP1600_OverwriteBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
 #                                       %rdi                        %rsi               %rdx                 %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_OverwriteBytes
 _KeccakP1600_OverwriteBytes:
 .else
 .globl  KeccakP1600_OverwriteBytes
+.ifndef no_type
 .type   KeccakP1600_OverwriteBytes,@function
+.endif
 KeccakP1600_OverwriteBytes:
 .endif
 .balign 32
@@ -169,8 +174,7 @@ KeccakP1600_OverwriteBytes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_OverwriteBytes_LastIncompleteLaneLoop
 KeccakP1600_OverwriteBytes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_OverwriteBytes,.-KeccakP1600_OverwriteBytes
 .endif
 
@@ -179,12 +183,14 @@ KeccakP1600_OverwriteBytes_Exit:
 # void KeccakP1600_OverwriteWithZeroes(void *state, unsigned int byteCount);
 #                                            %rdi                %rsi
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_OverwriteWithZeroes
 _KeccakP1600_OverwriteWithZeroes:
 .else
 .globl  KeccakP1600_OverwriteWithZeroes
+.ifndef no_type
 .type   KeccakP1600_OverwriteWithZeroes,@function
+.endif
 KeccakP1600_OverwriteWithZeroes:
 .endif
 .balign 32
@@ -207,8 +213,7 @@ KeccakP1600_OverwriteWithZeroes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_OverwriteWithZeroes_LastIncompleteLaneLoop
 KeccakP1600_OverwriteWithZeroes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_OverwriteWithZeroes,.-KeccakP1600_OverwriteWithZeroes
 .endif
 
@@ -217,12 +222,14 @@ KeccakP1600_OverwriteWithZeroes_Exit:
 # void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
 #                                           %rdi                  %rsi               %rdx                 %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_ExtractBytes
 _KeccakP1600_ExtractBytes:
 .else
 .globl  KeccakP1600_ExtractBytes
+.ifndef no_type
 .type   KeccakP1600_ExtractBytes,@function
+.endif
 KeccakP1600_ExtractBytes:
 .endif
 .balign 32
@@ -264,8 +271,7 @@ KeccakP1600_ExtractBytes_LastIncompleteLaneLoop:
     jnz         KeccakP1600_ExtractBytes_LastIncompleteLaneLoop
 KeccakP1600_ExtractBytes_Exit:
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_ExtractBytes,.-KeccakP1600_ExtractBytes
 .endif
 
@@ -274,12 +280,14 @@ KeccakP1600_ExtractBytes_Exit:
 # void KeccakP1600_ExtractAndAddBytes(const void *state, const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);
 #                                                 %rdi                        %rsi                  %rdx                 %rcx                  %r8
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_ExtractAndAddBytes
 _KeccakP1600_ExtractAndAddBytes:
 .else
 .globl  KeccakP1600_ExtractAndAddBytes
+.ifndef no_type
 .type   KeccakP1600_ExtractAndAddBytes,@function
+.endif
 KeccakP1600_ExtractAndAddBytes:
 .endif
 .balign 32
@@ -329,8 +337,7 @@ KeccakP1600_ExtractAndAddBytes_LastIncompleteLaneLoop:
 KeccakP1600_ExtractAndAddBytes_Exit:
     pop         %rbx
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_ExtractAndAddBytes,.-KeccakP1600_ExtractAndAddBytes
 .endif
 
@@ -339,8 +346,7 @@ KeccakP1600_ExtractAndAddBytes_Exit:
 # internal    
 #
 .text
-.ifdef macOS
-.else
+.ifndef no_type
 .type    __KeccakF1600,@function
 .endif
 .balign 32
@@ -451,8 +457,7 @@ __KeccakF1600:
     dec        %eax
     jnz        .Loop_avx512
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size    __KeccakF1600,.-__KeccakF1600
 .endif
 
@@ -461,12 +466,14 @@ __KeccakF1600:
 # void KeccakP1600_Permute_24rounds(void *state);
 #                                        %rdi
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Permute_24rounds
 _KeccakP1600_Permute_24rounds:
 .else
 .globl  KeccakP1600_Permute_24rounds
+.ifndef no_type
 .type   KeccakP1600_Permute_24rounds,@function
+.endif
 KeccakP1600_Permute_24rounds:
 .endif
 .balign 32
@@ -515,8 +522,7 @@ KeccakP1600_Permute_24rounds:
     vmovdqu64   %zmm4,40*4-96(%rdi){%k6}
     vzeroupper
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Permute_24rounds,.-KeccakP1600_Permute_24rounds
 .endif
 
@@ -525,12 +531,14 @@ KeccakP1600_Permute_24rounds:
 # void KeccakP1600_Permute_12rounds(void *state);
 #                                        %rdi
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Permute_12rounds
 _KeccakP1600_Permute_12rounds:
 .else
 .globl  KeccakP1600_Permute_12rounds
+.ifndef no_type
 .type   KeccakP1600_Permute_12rounds,@function
+.endif
 KeccakP1600_Permute_12rounds:
 .endif
 .balign 32
@@ -579,8 +587,7 @@ KeccakP1600_Permute_12rounds:
     vmovdqu64   %zmm4,40*4-96(%rdi){%k6}
     vzeroupper
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Permute_12rounds,.-KeccakP1600_Permute_12rounds
 .endif
 
@@ -589,12 +596,14 @@ KeccakP1600_Permute_12rounds:
 # void KeccakP1600_Permute_Nrounds(void *state, unsigned int nrounds);
 #                                        %rdi                %rsi
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_Permute_Nrounds
 _KeccakP1600_Permute_Nrounds:
 .else
 .globl  KeccakP1600_Permute_Nrounds
+.ifndef no_type
 .type   KeccakP1600_Permute_Nrounds,@function
+.endif
 KeccakP1600_Permute_Nrounds:
 .endif
 .balign 32
@@ -714,8 +723,7 @@ KeccakP1600_Permute_Nrounds:
     vmovdqu64   %zmm4,40*4-96(%rdi){%k6}
     vzeroupper
     ret
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_Permute_Nrounds,.-KeccakP1600_Permute_Nrounds
 .endif
 
@@ -724,12 +732,14 @@ KeccakP1600_Permute_Nrounds:
 # size_t KeccakF1600_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
 #                                          %rdi                %rsi                            %rdx         %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakF1600_FastLoop_Absorb
 _KeccakF1600_FastLoop_Absorb:
 .else
 .globl  KeccakF1600_FastLoop_Absorb
+.ifndef no_type
 .type   KeccakF1600_FastLoop_Absorb,@function
+.endif
 KeccakF1600_FastLoop_Absorb:
 .endif
 .balign 32
@@ -843,8 +853,12 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
     push            %rsi
     push            %rdx
     push            %rcx
-.ifdef macOS
+.ifdef no_plt
+.ifdef add_underscore
     call            _KeccakP1600_Permute_24rounds
+.else
+    call            KeccakP1600_Permute_24rounds
+.endif
 .else
     call            KeccakP1600_Permute_24rounds@PLT
 .endif
@@ -855,8 +869,7 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
     cmp             %rsi, %rcx
     jae             KeccakF1600_FastLoop_Absorb_LanesLoop
     jmp             KeccakF1600_FastLoop_Absorb_Exit
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakF1600_FastLoop_Absorb,.-KeccakF1600_FastLoop_Absorb
 .endif
 
@@ -865,12 +878,14 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
 # size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
 #                                          %rdi                %rsi                            %rdx         %rcx
 #
-.ifdef macOS
+.ifdef add_underscore
 .globl  _KeccakP1600_12rounds_FastLoop_Absorb
 _KeccakP1600_12rounds_FastLoop_Absorb:
 .else
 .globl  KeccakP1600_12rounds_FastLoop_Absorb
+.ifndef no_type
 .type   KeccakP1600_12rounds_FastLoop_Absorb,@function
+.endif
 KeccakP1600_12rounds_FastLoop_Absorb:
 .endif
 .balign 32
@@ -984,8 +999,12 @@ KeccakP1600_FastLoop_Absorb_LanesAddLoop:
     push            %rsi
     push            %rdx
     push            %rcx
-.ifdef macOS
+.ifdef no_plt
+.ifdef add_underscore
     call            _KeccakP1600_Permute_12rounds
+.else
+    call            KeccakP1600_Permute_12rounds
+.endif
 .else
     call            KeccakP1600_Permute_12rounds@PLT
 .endif
@@ -996,8 +1015,7 @@ KeccakP1600_FastLoop_Absorb_LanesAddLoop:
     cmp             %rsi, %rcx
     jae             KeccakP1600_FastLoop_Absorb_LanesLoop
     jmp             KeccakP1600_FastLoop_Absorb_Exit
-.ifdef macOS
-.else
+.ifndef no_size
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
 .endif
 .balign 64

--- a/lib/low/KeccakP-1600/AVX512/KeccakP-1600-SnP.h
+++ b/lib/low/KeccakP-1600/AVX512/KeccakP-1600-SnP.h
@@ -23,6 +23,12 @@ Please refer to SnP-documentation.h for more details.
 
 #include <stddef.h>
 
+#ifdef __MINGW32__
+#define FORCE_SYSV __attribute__((sysv_abi))
+#else
+#define FORCE_SYSV
+#endif
+
 #define KeccakP1600_implementation      "AVX-512 optimized implementation"
 #define KeccakP1600_stateSizeInBytes    200
 #define KeccakP1600_stateAlignment      8
@@ -30,18 +36,18 @@ Please refer to SnP-documentation.h for more details.
 #define KeccakP1600_12rounds_FastLoop_supported
 
 #define KeccakP1600_StaticInitialize()
-void KeccakP1600_Initialize(void *state);
+FORCE_SYSV void KeccakP1600_Initialize(void *state);
 //void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset);
 #define KeccakP1600_AddByte(state, byte, offset) ((unsigned char*)(state))[(offset)] ^= (byte)
-void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakP1600_OverwriteBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakP1600_OverwriteWithZeroes(void *state, unsigned int byteCount);
-void KeccakP1600_Permute_Nrounds(void *state, unsigned int nrounds);
-void KeccakP1600_Permute_12rounds(void *state);
-void KeccakP1600_Permute_24rounds(void *state);
-void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakP1600_ExtractAndAddBytes(const void *state, const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);
-size_t KeccakF1600_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
-size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
+FORCE_SYSV void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
+FORCE_SYSV void KeccakP1600_OverwriteBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
+FORCE_SYSV void KeccakP1600_OverwriteWithZeroes(void *state, unsigned int byteCount);
+FORCE_SYSV void KeccakP1600_Permute_Nrounds(void *state, unsigned int nrounds);
+FORCE_SYSV void KeccakP1600_Permute_12rounds(void *state);
+FORCE_SYSV void KeccakP1600_Permute_24rounds(void *state);
+FORCE_SYSV void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
+FORCE_SYSV void KeccakP1600_ExtractAndAddBytes(const void *state, const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);
+FORCE_SYSV size_t KeccakF1600_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
+FORCE_SYSV size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
 
 #endif

--- a/support/Build/ToTargetMakefile.xsl
+++ b/support/Build/ToTargetMakefile.xsl
@@ -200,9 +200,11 @@ ifeq ($(UNAME_S),Linux)
     ASMFLAGS :=
 endif
 ifeq ($(UNAME_S),Darwin)
-    ASMFLAGS := -x assembler-with-cpp -Wa,-defsym,macOS=1
+    ASMFLAGS := -x assembler-with-cpp -Wa,-defsym,add_underscore=1 -Wa,-defsym,no_size=1 -Wa,-defsym,no_plt=1
 endif
-
+ifneq (,$(findstring mingw32,$(CC)))
+    ASMFLAGS := -x assembler-with-cpp -Wa,-defsym,no_type=1 -Wa,-defsym,no_size=1 -Wa,-defsym,no_plt=1
+endif
 UNAME_M := $(shell uname -m)
 
 </xsl:text>


### PR DESCRIPTION
Adds/changes ifdefs in the KeccakP-1600-*.s to support compilation
and linking with mingw-w64, extending earlier work to support macOS.

KeccakP-1600-SnP.h forces usage of the System V AMD64 ABI when built
with mingw to ensure the correct registers are used to pass args
to the assembly code.

ToTargetMakefile.xsl is modified to pass the correct defines to AS
for both macOS and mingw builds.