### PR TITLE
Add CFLAGS to linker to build for MacOS/ARM

### DIFF
--- a/support/Build/ToTargetMakefile.xsl
+++ b/support/Build/ToTargetMakefile.xsl
@@ -271,7 +271,7 @@ bin/</xsl:text>
 &#9;cp -f $(HEADERS) $@.headers/
 &#9;$(CC) -dynamiclib -install_name @rpath/</xsl:text>
         <xsl:value-of select="@name"/>
-        <xsl:text> $(OBJECTS) -o $@
+        <xsl:text> $(CFLAGS) $(OBJECTS) -o $@
 </xsl:text>
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
When building for MacOS/ARM on x86 or M1, without this patch the object files can be created with the correct arch but are then linked as x86 and so fails.  The patch simply includes the CFLAGS that were previously specified, to the linking step.  It does not appear to cause any problems with builds for other platforms including various optimisations.