### PR TITLE
Add MinGW, MSys support

### DIFF
--- a/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
+++ b/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
@@ -25,7 +25,9 @@
 .globl  KeccakP1600_Initialize
 .globl _KeccakP1600_Initialize
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Initialize,@function
+.endif
 .endif
 KeccakP1600_Initialize:
 _KeccakP1600_Initialize:
@@ -40,7 +42,9 @@ _KeccakP1600_Initialize:
     movq        $0,6*32(%rdi)
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Initialize,.-KeccakP1600_Initialize
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -51,7 +55,9 @@ _KeccakP1600_Initialize:
 .globl  KeccakP1600_AddByte
 .globl _KeccakP1600_AddByte
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_AddByte,@function
+.endif
 .endif
 KeccakP1600_AddByte:
 _KeccakP1600_AddByte:
@@ -66,7 +72,9 @@ _KeccakP1600_AddByte:
     xorb        %sil, (%rdi)
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_AddByte,.-KeccakP1600_AddByte
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -77,7 +85,9 @@ _KeccakP1600_AddByte:
 .globl  KeccakP1600_AddBytes
 .globl _KeccakP1600_AddBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_AddBytes,@function
+.endif
 .endif
 KeccakP1600_AddBytes:
 _KeccakP1600_AddBytes:
@@ -131,7 +141,9 @@ KeccakP1600_AddBytes_LastIncompleteLaneLoop:
 KeccakP1600_AddBytes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_AddBytes,.-KeccakP1600_AddBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -142,7 +154,9 @@ KeccakP1600_AddBytes_Exit:
 .globl  KeccakP1600_OverwriteBytes
 .globl _KeccakP1600_OverwriteBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_OverwriteBytes,@function
+.endif
 .endif
 KeccakP1600_OverwriteBytes:
 _KeccakP1600_OverwriteBytes:
@@ -196,7 +210,9 @@ KeccakP1600_OverwriteBytes_LastIncompleteLaneLoop:
 KeccakP1600_OverwriteBytes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_OverwriteBytes,.-KeccakP1600_OverwriteBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -207,7 +223,9 @@ KeccakP1600_OverwriteBytes_Exit:
 .globl  KeccakP1600_OverwriteWithZeroes
 .globl _KeccakP1600_OverwriteWithZeroes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_OverwriteWithZeroes,@function
+.endif
 .endif
 KeccakP1600_OverwriteWithZeroes:
 _KeccakP1600_OverwriteWithZeroes:
@@ -237,7 +255,9 @@ KeccakP1600_OverwriteWithZeroes_LastIncompleteLaneLoop:
 KeccakP1600_OverwriteWithZeroes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_OverwriteWithZeroes,.-KeccakP1600_OverwriteWithZeroes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -248,7 +268,9 @@ KeccakP1600_OverwriteWithZeroes_Exit:
 .globl  KeccakP1600_ExtractBytes
 .globl _KeccakP1600_ExtractBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_ExtractBytes,@function
+.endif
 .endif
 KeccakP1600_ExtractBytes:
 _KeccakP1600_ExtractBytes:
@@ -305,7 +327,9 @@ KeccakP1600_ExtractBytes_Exit:
     pop         %rbx
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_ExtractBytes,.-KeccakP1600_ExtractBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -316,7 +340,9 @@ KeccakP1600_ExtractBytes_Exit:
 .globl  KeccakP1600_ExtractAndAddBytes
 .globl _KeccakP1600_ExtractAndAddBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_ExtractAndAddBytes,@function
+.endif
 .endif
 KeccakP1600_ExtractAndAddBytes:
 _KeccakP1600_ExtractAndAddBytes:
@@ -381,7 +407,9 @@ KeccakP1600_ExtractAndAddBytes_Exit:
     pop         %rbx
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_ExtractAndAddBytes,.-KeccakP1600_ExtractAndAddBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -389,7 +417,9 @@ KeccakP1600_ExtractAndAddBytes_Exit:
 # internal    
 #
 .ifndef old_gas_syntax
+.ifndef no_type
 .type    __KeccakF1600,@function
+.endif
 .endif
 .balign 32
 __KeccakF1600:
@@ -531,7 +561,9 @@ __KeccakF1600:
     jnz         .Loop_avx2
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   __KeccakF1600,.-__KeccakF1600
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -542,7 +574,9 @@ __KeccakF1600:
 .globl  KeccakP1600_Permute_24rounds
 .globl _KeccakP1600_Permute_24rounds
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Permute_24rounds,@function
+.endif
 .endif
 KeccakP1600_Permute_24rounds:
 _KeccakP1600_Permute_24rounds:
@@ -571,7 +605,9 @@ _KeccakP1600_Permute_24rounds:
     vzeroupper
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Permute_24rounds,.-KeccakP1600_Permute_24rounds
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -582,7 +618,9 @@ _KeccakP1600_Permute_24rounds:
 .globl  KeccakP1600_Permute_12rounds
 .globl _KeccakP1600_Permute_12rounds
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Permute_12rounds,@function
+.endif
 .endif
 KeccakP1600_Permute_12rounds:
 _KeccakP1600_Permute_12rounds:
@@ -611,7 +649,9 @@ _KeccakP1600_Permute_12rounds:
     vzeroupper
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Permute_12rounds,.-KeccakP1600_Permute_12rounds
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -622,7 +662,9 @@ _KeccakP1600_Permute_12rounds:
 .globl  KeccakP1600_Permute_Nrounds
 .globl _KeccakP1600_Permute_Nrounds
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Permute_Nrounds,@function
+.endif
 .endif
 KeccakP1600_Permute_Nrounds:
 _KeccakP1600_Permute_Nrounds:
@@ -653,7 +695,9 @@ _KeccakP1600_Permute_Nrounds:
     vzeroupper
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Permute_Nrounds,.-KeccakP1600_Permute_Nrounds
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -664,7 +708,9 @@ _KeccakP1600_Permute_Nrounds:
 .globl  KeccakF1600_FastLoop_Absorb
 .globl _KeccakF1600_FastLoop_Absorb
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakF1600_FastLoop_Absorb,@function
+.endif
 .endif
 KeccakF1600_FastLoop_Absorb:
 _KeccakF1600_FastLoop_Absorb:
@@ -832,7 +878,9 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
     jae             KeccakF1600_FastLoop_Absorb_Not17Lanes
     jmp             KeccakF1600_FastLoop_Absorb_Exit
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakF1600_FastLoop_Absorb,.-KeccakF1600_FastLoop_Absorb
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -843,7 +891,9 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
 .globl  KeccakP1600_12rounds_FastLoop_Absorb
 .globl _KeccakP1600_12rounds_FastLoop_Absorb
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_12rounds_FastLoop_Absorb,@function
+.endif
 .endif
 KeccakP1600_12rounds_FastLoop_Absorb:
 _KeccakP1600_12rounds_FastLoop_Absorb:
@@ -1011,7 +1061,9 @@ KeccakP1600_12rounds_FastLoop_Absorb_LanesAddLoop:
     jae             KeccakP1600_12rounds_FastLoop_Absorb_Not17Lanes
     jmp             KeccakP1600_12rounds_FastLoop_Absorb_Exit
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
+.endif
 .endif
 
 .equ    ALLON,        0xFFFFFFFFFFFFFFFF

--- a/lib/low/KeccakP-1600/AVX512/KeccakP-1600-AVX512.s
+++ b/lib/low/KeccakP-1600/AVX512/KeccakP-1600-AVX512.s
@@ -25,7 +25,9 @@
 .globl  KeccakP1600_Initialize
 .globl _KeccakP1600_Initialize
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Initialize,@function
+.endif
 .endif
 KeccakP1600_Initialize:
 _KeccakP1600_Initialize:
@@ -37,7 +39,9 @@ _KeccakP1600_Initialize:
     movq        $0,3*64(%rdi)
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Initialize,.-KeccakP1600_Initialize
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -67,7 +71,9 @@ _KeccakP1600_Initialize:
 .globl  KeccakP1600_AddBytes
 .globl _KeccakP1600_AddBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_AddBytes,@function
+.endif
 .endif
 KeccakP1600_AddBytes:
 _KeccakP1600_AddBytes:
@@ -111,7 +117,9 @@ KeccakP1600_AddBytes_LastIncompleteLaneLoop:
 KeccakP1600_AddBytes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_AddBytes,.-KeccakP1600_AddBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -122,7 +130,9 @@ KeccakP1600_AddBytes_Exit:
 .globl  KeccakP1600_OverwriteBytes
 .globl _KeccakP1600_OverwriteBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_OverwriteBytes,@function
+.endif
 .endif
 KeccakP1600_OverwriteBytes:
 _KeccakP1600_OverwriteBytes:
@@ -166,7 +176,9 @@ KeccakP1600_OverwriteBytes_LastIncompleteLaneLoop:
 KeccakP1600_OverwriteBytes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_OverwriteBytes,.-KeccakP1600_OverwriteBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -177,7 +189,9 @@ KeccakP1600_OverwriteBytes_Exit:
 .globl  KeccakP1600_OverwriteWithZeroes
 .globl _KeccakP1600_OverwriteWithZeroes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_OverwriteWithZeroes,@function
+.endif
 .endif
 KeccakP1600_OverwriteWithZeroes:
 _KeccakP1600_OverwriteWithZeroes:
@@ -202,7 +216,9 @@ KeccakP1600_OverwriteWithZeroes_LastIncompleteLaneLoop:
 KeccakP1600_OverwriteWithZeroes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_OverwriteWithZeroes,.-KeccakP1600_OverwriteWithZeroes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -213,7 +229,9 @@ KeccakP1600_OverwriteWithZeroes_Exit:
 .globl  KeccakP1600_ExtractBytes
 .globl _KeccakP1600_ExtractBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_ExtractBytes,@function
+.endif
 .endif
 KeccakP1600_ExtractBytes:
 _KeccakP1600_ExtractBytes:
@@ -257,7 +275,9 @@ KeccakP1600_ExtractBytes_LastIncompleteLaneLoop:
 KeccakP1600_ExtractBytes_Exit:
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_ExtractBytes,.-KeccakP1600_ExtractBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -268,7 +288,9 @@ KeccakP1600_ExtractBytes_Exit:
 .globl  KeccakP1600_ExtractAndAddBytes
 .globl _KeccakP1600_ExtractAndAddBytes
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_ExtractAndAddBytes,@function
+.endif
 .endif
 KeccakP1600_ExtractAndAddBytes:
 _KeccakP1600_ExtractAndAddBytes:
@@ -320,7 +342,9 @@ KeccakP1600_ExtractAndAddBytes_Exit:
     pop         %rbx
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_ExtractAndAddBytes,.-KeccakP1600_ExtractAndAddBytes
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -329,7 +353,9 @@ KeccakP1600_ExtractAndAddBytes_Exit:
 #
 .text
 .ifndef old_gas_syntax
+.ifndef no_type
 .type    __KeccakF1600,@function
+.endif
 .endif
 .balign 32
 __KeccakF1600:
@@ -440,7 +466,9 @@ __KeccakF1600:
     jnz        .Loop_avx512
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size    __KeccakF1600,.-__KeccakF1600
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -451,7 +479,9 @@ __KeccakF1600:
 .globl  KeccakP1600_Permute_24rounds
 .globl _KeccakP1600_Permute_24rounds
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Permute_24rounds,@function
+.endif
 .endif
 KeccakP1600_Permute_24rounds:
 _KeccakP1600_Permute_24rounds:
@@ -502,7 +532,9 @@ _KeccakP1600_Permute_24rounds:
     vzeroupper
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Permute_24rounds,.-KeccakP1600_Permute_24rounds
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -513,7 +545,9 @@ _KeccakP1600_Permute_24rounds:
 .globl  KeccakP1600_Permute_12rounds
 .globl _KeccakP1600_Permute_12rounds
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Permute_12rounds,@function
+.endif
 .endif
 KeccakP1600_Permute_12rounds:
 _KeccakP1600_Permute_12rounds:
@@ -564,7 +598,9 @@ _KeccakP1600_Permute_12rounds:
     vzeroupper
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Permute_12rounds,.-KeccakP1600_Permute_12rounds
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -575,7 +611,9 @@ _KeccakP1600_Permute_12rounds:
 .globl  KeccakP1600_Permute_Nrounds
 .globl _KeccakP1600_Permute_Nrounds
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_Permute_Nrounds,@function
+.endif
 .endif
 KeccakP1600_Permute_Nrounds:
 _KeccakP1600_Permute_Nrounds:
@@ -697,7 +735,9 @@ _KeccakP1600_Permute_Nrounds:
     vzeroupper
     ret
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_Permute_Nrounds,.-KeccakP1600_Permute_Nrounds
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -708,7 +748,9 @@ _KeccakP1600_Permute_Nrounds:
 .globl  KeccakF1600_FastLoop_Absorb
 .globl _KeccakF1600_FastLoop_Absorb
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakF1600_FastLoop_Absorb,@function
+.endif
 .endif
 KeccakF1600_FastLoop_Absorb:
 _KeccakF1600_FastLoop_Absorb:
@@ -836,7 +878,9 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
     jae             KeccakF1600_FastLoop_Absorb_LanesLoop
     jmp             KeccakF1600_FastLoop_Absorb_Exit
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakF1600_FastLoop_Absorb,.-KeccakF1600_FastLoop_Absorb
+.endif
 .endif
 
 # -----------------------------------------------------------------------------
@@ -847,7 +891,9 @@ KeccakF1600_FastLoop_Absorb_LanesAddLoop:
 .globl  KeccakP1600_12rounds_FastLoop_Absorb
 .globl _KeccakP1600_12rounds_FastLoop_Absorb
 .ifndef old_gas_syntax
+.ifndef no_type
 .type   KeccakP1600_12rounds_FastLoop_Absorb,@function
+.endif
 .endif
 KeccakP1600_12rounds_FastLoop_Absorb:
 _KeccakP1600_12rounds_FastLoop_Absorb:
@@ -975,7 +1021,9 @@ KeccakP1600_FastLoop_Absorb_LanesAddLoop:
     jae             KeccakP1600_FastLoop_Absorb_LanesLoop
     jmp             KeccakP1600_FastLoop_Absorb_Exit
 .ifndef old_gas_syntax
+.ifndef no_size
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
+.endif
 .endif
 .balign 64
 theta_perm:

--- a/support/Build/ToTargetMakefile.xsl
+++ b/support/Build/ToTargetMakefile.xsl
@@ -217,6 +217,12 @@ endif
 ifneq (,$(findstring mingw32,$(CC)))
     ASMFLAGS := -x assembler-with-cpp -Wa,-defsym,old_gas_syntax=1 -Wa,-defsym,no_plt=1
 endif
+ifneq (,$(findstring MINGW,$(UNAME_S)))
+    ASMFLAGS := -x assembler-with-cpp -Wa,-defsym,no_type=1 -Wa,-defsym,no_size=1 -Wa,-defsym,no_plt=1
+endif
+ifneq (,$(findstring MSYS_NT,$(UNAME_S)))
+    ASMFLAGS := -x assembler-with-cpp -Wa,-defsym,no_type=1 -Wa,-defsym,no_size=1 -Wa,-defsym,no_plt=1
+endif
 UNAME_M := $(shell uname -m)
 
 </xsl:text>


### PR DESCRIPTION
This PR adds support for MinGW and MSys targets.

This requires adding respect for the no_type and no_size symbol definitions to [KeccakP-1600-AVX2.s](https://github.com/XKCP/XKCP/compare/master...StirlingLabs:XKCP:feature/mingw-msys-support?expand=1#diff-2a046be16ff7c0d28a270423f7bd0e4364e2fa70953eb8828c3c3e124aae611e) and [KeccakP-1600-AVX512.s](https://github.com/XKCP/XKCP/compare/master...StirlingLabs:XKCP:feature/mingw-msys-support?expand=1#diff-73aa463a7d87a16eef85c4e25f05a4004b180944cea1accf58ee79ff7cb6b534).

