### PR TITLE
Cleans up warnings so that Xoofff can be used in a FreeBSD kernel driver

### DIFF
--- a/lib/high/Xoofff/Xoofff.c
+++ b/lib/high/Xoofff/Xoofff.c
@@ -281,16 +281,16 @@ void Xoofff_AddIs(unsigned char *output, const unsigned char *input, size_t bitL
 
     #if !defined(NO_MISALIGNED_ACCESSES)
     while ( byteLen >= 32 ) {
-        *((uint64_t*)(output+0)) ^= *((uint64_t*)(input+0));
-        *((uint64_t*)(output+8)) ^= *((uint64_t*)(input+8));
-        *((uint64_t*)(output+16)) ^= *((uint64_t*)(input+16));
-        *((uint64_t*)(output+24)) ^= *((uint64_t*)(input+24));
+        *((uint64_t*)(output+0)) ^= *((const uint64_t*)(input+0));
+        *((uint64_t*)(output+8)) ^= *((const uint64_t*)(input+8));
+        *((uint64_t*)(output+16)) ^= *((const uint64_t*)(input+16));
+        *((uint64_t*)(output+24)) ^= *((const uint64_t*)(input+24));
         input += 32;
         output += 32;
         byteLen -= 32;
     }
     while ( byteLen >= 8 ) {
-        *((uint64_t*)output) ^= *((uint64_t*)input);
+        *((uint64_t*)output) ^= *((const uint64_t*)input);
         input += 8;
         output += 8;
         byteLen -= 8;

--- a/lib/low/Xoodoo-times16/AVX512/Xoodoo-times16-SIMD512.c
+++ b/lib/low/Xoodoo-times16/AVX512/Xoodoo-times16-SIMD512.c
@@ -539,7 +539,7 @@ void Xoodootimes16_ExtractBytes(const void *states, unsigned int instanceIndex, 
         unsigned int bytesInLane = SnP_laneLengthInBytes - offsetInLane;
         if (bytesInLane > sizeLeft)
             bytesInLane = sizeLeft;
-        memcpy( curData, ((unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
+        memcpy( curData, ((const unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
         sizeLeft -= bytesInLane;
         lanePosition++;
         curData += bytesInLane;
@@ -611,7 +611,7 @@ void Xoodootimes16_ExtractAndAddBytes(const void *states, unsigned int instanceI
     }
 
     while(sizeLeft >= SnP_laneLengthInBytes) {
-        *((uint32_t*)curOutput) = *((uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
+        *((uint32_t*)curOutput) = *((const uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
         sizeLeft -= SnP_laneLengthInBytes;
         lanePosition++;
         curInput += SnP_laneLengthInBytes;
@@ -802,7 +802,7 @@ void Xooffftimes16_AddIs(unsigned char *output, const unsigned char *input, size
         output += 32;
     }
    while ( byteLen >= 8 ) {
-        *((uint64_t*)output) ^= *((uint64_t*)input);
+        *((uint64_t*)output) ^= *((const uint64_t*)input);
         input += 8;
         output += 8;
         byteLen -= 8;
@@ -822,9 +822,9 @@ void Xooffftimes16_AddIs(unsigned char *output, const unsigned char *input, size
 size_t Xooffftimes16_CompressFastLoop(unsigned char *k, unsigned char *x, const unsigned char *input, size_t length)
 {
     DeclareVars;
-    uint32_t    *k32 = (uint32_t*)k;
-    uint32_t    *x32 = (uint32_t*)x;
-    uint32_t    *i32 = (uint32_t*)input;
+    uint32_t       *k32 = (uint32_t*)k;
+    uint32_t       *x32 = (uint32_t*)x;
+    const uint32_t *i32 = (const uint32_t*)input;
     size_t      initialLength;
     V512        rCGKDHLEIcgkdhlei;
     V512        offsets;
@@ -832,7 +832,7 @@ size_t Xooffftimes16_CompressFastLoop(unsigned char *k, unsigned char *x, const 
 
     DUMP32("k32",k32);
     rCGKDHLEIcgkdhlei = LOAD_GATHER16_32(*(const V512*)oGatherScatterOffsetsRoll, k32);
-    offsets = *(V512*)oGatherScatterOffsets;
+    offsets = *(const V512*)oGatherScatterOffsets;
 
     x00 = _mm512_setzero_si512();
     x01 = _mm512_setzero_si512();
@@ -914,8 +914,8 @@ size_t Xooffftimes16_CompressFastLoop(unsigned char *k, unsigned char *x, const 
     while (length >= (NLANES*4*16));
 
     /*    Reduce from lanes 16 to 8 */
-    v1 = *(V512*)oLow256;
-    v2 = *(V512*)oHigh256;
+    v1 = *(const V512*)oLow256;
+    v2 = *(const V512*)oHigh256;
     x00 = XOR(_mm512_permutex2var_epi32(x00, v1, x10), _mm512_permutex2var_epi32(x00, v2, x10));
     x01 = XOR(_mm512_permutex2var_epi32(x01, v1, x11), _mm512_permutex2var_epi32(x01, v2, x11));
     x02 = XOR(_mm512_permutex2var_epi32(x02, v1, x12), _mm512_permutex2var_epi32(x02, v2, x12));
@@ -924,20 +924,20 @@ size_t Xooffftimes16_CompressFastLoop(unsigned char *k, unsigned char *x, const 
     x21 = XOR(_mm512_permutex2var_epi32(x21, v1, x23), _mm512_permutex2var_epi32(x21, v2, x23));
 
     /*    Reduce from 8 lanes to 4 */
-    v1 = *( V512*)oLow128;
-    v2 = *( V512*)oHigh128;
+    v1 = *(const V512*)oLow128;
+    v2 = *(const V512*)oHigh128;
     x00 = XOR(_mm512_permutex2var_epi32(x00, v1, x02), _mm512_permutex2var_epi32(x00, v2, x02));
     x01 = XOR(_mm512_permutex2var_epi32(x01, v1, x03), _mm512_permutex2var_epi32(x01, v2, x03));
     x20 = XOR(_mm512_permutex2var_epi32(x20, v1, x21), _mm512_permutex2var_epi32(x20, v2, x21));
 
     /*    Reduce from 4 lanes to 2 */
-    v1 = *(V512*)oLow64;
-    v2 = *(V512*)oHigh64;
+    v1 = *(const V512*)oLow64;
+    v2 = *(const V512*)oHigh64;
     x00 = XOR(_mm512_permutex2var_epi32(x00, v1, x01), _mm512_permutex2var_epi32(x00, v2, x01));
     x20 = XOR(_mm512_permutex2var_epi32(x20, v1, x20), _mm512_permutex2var_epi32(x20, v2, x20));
 
     /*    Reduce from 2 lanes to 1 */
-    x00 = XOR(_mm512_permutex2var_epi32(x00, *(V512*)oLow32, x20), _mm512_permutex2var_epi32(x00, *(V512*)oHigh32, x20));
+    x00 = XOR(_mm512_permutex2var_epi32(x00, *(const V512*)oLow32, x20), _mm512_permutex2var_epi32(x00, *(const V512*)oHigh32, x20));
 
     /*  load xAccu, xor and store 12 lanes */
     x01 = _mm512_maskz_load_epi64(0x3F, x32);
@@ -955,9 +955,9 @@ size_t Xooffftimes16_CompressFastLoop(unsigned char *k, unsigned char *x, const 
 size_t Xooffftimes16_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kRoll, unsigned char *output, size_t length)
 {
     DeclareVars;
-    uint32_t    *k32 = (uint32_t*)kRoll;
-    uint32_t    *y32 = (uint32_t*)yAccu;
-    uint32_t    *o32 = (uint32_t*)output;
+    const uint32_t *k32 = (const uint32_t*)kRoll;
+    uint32_t       *y32 = (uint32_t*)yAccu;
+    uint32_t       *o32 = (uint32_t*)output;
     size_t      initialLength;
     V512        rCGKDHLEIcgkdhlei;
     V512        offsets;

--- a/lib/low/Xoodoo-times4/AVX512/Xoodoo-times4-SIMD512.c
+++ b/lib/low/Xoodoo-times4/AVX512/Xoodoo-times4-SIMD512.c
@@ -687,7 +687,7 @@ void Xoodootimes4_ExtractBytes(const void *states, unsigned int instanceIndex, u
         unsigned int bytesInLane = SnP_laneLengthInBytes - offsetInLane;
         if (bytesInLane > sizeLeft)
             bytesInLane = sizeLeft;
-        memcpy( curData, ((unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
+        memcpy( curData, ((const unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
         sizeLeft -= bytesInLane;
         lanePosition++;
         curData += bytesInLane;
@@ -758,7 +758,7 @@ void Xoodootimes4_ExtractAndAddBytes(const void *states, unsigned int instanceIn
     }
 
     while(sizeLeft >= SnP_laneLengthInBytes) {
-        *((uint32_t*)curOutput) = *((uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
+        *((uint32_t*)curOutput) = *((const uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
         sizeLeft -= SnP_laneLengthInBytes;
         lanePosition++;
         curInput += SnP_laneLengthInBytes;
@@ -949,7 +949,7 @@ void Xooffftimes4_AddIs(unsigned char *output, const unsigned char *input, size_
         output += 32;
     }
    while ( byteLen >= 8 ) {
-        *((uint64_t*)output) ^= *((uint64_t*)input);
+        *((uint64_t*)output) ^= *((const uint64_t*)input);
         input += 8;
         output += 8;
         byteLen -= 8;
@@ -969,9 +969,9 @@ void Xooffftimes4_AddIs(unsigned char *output, const unsigned char *input, size_
 size_t Xooffftimes4_CompressFastLoop(unsigned char *k, unsigned char *x, const unsigned char *input, size_t length)
 {
     DeclareVars;
-    uint32_t    *k32 = (uint32_t*)k;
-    uint32_t    *x32 = (uint32_t*)x;
-    uint32_t    *i32 = (uint32_t*)input;
+    uint32_t       *k32 = (uint32_t*)k;
+    uint32_t       *x32 = (uint32_t*)x;
+    const uint32_t *i32 = (const uint32_t*)input;
     size_t      initialLength;
     V128        r0481;
     V128        r5926;
@@ -986,7 +986,7 @@ size_t Xooffftimes4_CompressFastLoop(unsigned char *k, unsigned char *x, const u
     r5926 = LOAD_GATHER4_32(LOAD4_32(  5,  9,  2,  6), k32);
     ra37b = LOAD_GATHER4_32(LOAD4_32( 10,  3,  7, 11), k32);
 
-    offsets = *(V128*)oGatherScatterOffsets;
+    offsets = *(const V128*)oGatherScatterOffsets;
 
     x00 = _mm_setzero_si128();
     x01 = _mm_setzero_si128();
@@ -1069,8 +1069,8 @@ size_t Xooffftimes4_CompressFastLoop(unsigned char *k, unsigned char *x, const u
     while (length >= (NLANES*4*4));
 
     /*    Reduce from 4 lanes to 2 */
-    v1 = *(V128*)oLow64;
-    v2 = *(V128*)oHigh64;
+    v1 = *(const V128*)oLow64;
+    v2 = *(const V128*)oHigh64;
     x00 = XOR(_mm_permutex2var_epi32(x00, v1, x02), _mm_permutex2var_epi32(x00, v2, x02));
     x01 = XOR(_mm_permutex2var_epi32(x01, v1, x03), _mm_permutex2var_epi32(x01, v2, x03));
     x10 = XOR(_mm_permutex2var_epi32(x10, v1, x12), _mm_permutex2var_epi32(x10, v2, x12));
@@ -1079,8 +1079,8 @@ size_t Xooffftimes4_CompressFastLoop(unsigned char *k, unsigned char *x, const u
     x21 = XOR(_mm_permutex2var_epi32(x21, v1, x23), _mm_permutex2var_epi32(x21, v2, x23));
 
     /*    Reduce from 2 lanes to 1 */
-    v1 = *( V128*)oLow32;
-    v2 = *( V128*)oHigh32;
+    v1 = *(const V128*)oLow32;
+    v2 = *(const V128*)oHigh32;
     x00 = XOR(_mm_permutex2var_epi32(x00, v1, x01), _mm_permutex2var_epi32(x00, v2, x01));
     x10 = XOR(_mm_permutex2var_epi32(x10, v1, x11), _mm_permutex2var_epi32(x10, v2, x11));
     x20 = XOR(_mm_permutex2var_epi32(x20, v1, x21), _mm_permutex2var_epi32(x20, v2, x21));
@@ -1108,9 +1108,9 @@ size_t Xooffftimes4_CompressFastLoop(unsigned char *k, unsigned char *x, const u
 size_t Xooffftimes4_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kRoll, unsigned char *output, size_t length)
 {
     DeclareVars;
-    uint32_t    *k32 = (uint32_t*)kRoll;
-    uint32_t    *y32 = (uint32_t*)yAccu;
-    uint32_t    *o32 = (uint32_t*)output;
+    const uint32_t *k32 = (const uint32_t*)kRoll;
+    uint32_t       *y32 = (uint32_t*)yAccu;
+    uint32_t       *o32 = (uint32_t*)output;
     size_t      initialLength;
     V128        r0481;
     V128        r5926;
@@ -1121,7 +1121,7 @@ size_t Xooffftimes4_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kR
     r5926 = LOAD_GATHER4_32(LOAD4_32(  5,  9,  2,  6), y32);
     ra37b = LOAD_GATHER4_32(LOAD4_32( 10,  3,  7, 11), y32);
 
-    offsets = *(V128*)oGatherScatterOffsets;
+    offsets = *(const V128*)oGatherScatterOffsets;
 
     initialLength = length;
     do {

--- a/lib/low/Xoodoo-times4/SSSE3/Xoodoo-times4-SIMD128.c
+++ b/lib/low/Xoodoo-times4/SSSE3/Xoodoo-times4-SIMD128.c
@@ -241,7 +241,7 @@ void Xoodootimes4_ExtractBytes(const void *states, unsigned int instanceIndex, u
         unsigned int bytesInLane = SnP_laneLengthInBytes - offsetInLane;
         if (bytesInLane > sizeLeft)
             bytesInLane = sizeLeft;
-        memcpy( curData, ((unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
+        memcpy( curData, ((const unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
         sizeLeft -= bytesInLane;
         lanePosition++;
         curData += bytesInLane;
@@ -316,7 +316,7 @@ void Xoodootimes4_ExtractAndAddBytes(const void *states, unsigned int instanceIn
     }
 
     while(sizeLeft >= SnP_laneLengthInBytes) {
-        *((uint32_t*)curOutput) = *((uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
+        *((uint32_t*)curOutput) = *((const uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
         sizeLeft -= SnP_laneLengthInBytes;
         lanePosition++;
         curInput += SnP_laneLengthInBytes;

--- a/lib/low/Xoodoo-times8/AVX2/Xoodoo-times8-SIMD256.c
+++ b/lib/low/Xoodoo-times8/AVX2/Xoodoo-times8-SIMD256.c
@@ -289,7 +289,7 @@ void Xoodootimes8_ExtractBytes(const void *states, unsigned int instanceIndex, u
         unsigned int bytesInLane = SnP_laneLengthInBytes - offsetInLane;
         if (bytesInLane > sizeLeft)
             bytesInLane = sizeLeft;
-        memcpy( curData, ((unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
+        memcpy( curData, ((const unsigned char *)&statesAsLanes[laneIndex(instanceIndex, lanePosition)]) + offsetInLane, bytesInLane);
         sizeLeft -= bytesInLane;
         lanePosition++;
         curData += bytesInLane;
@@ -317,7 +317,6 @@ void Xoodootimes8_ExtractLanesAll(const void *states, unsigned char *data, unsig
     uint32_t *curData5 = (uint32_t *)(data+laneOffset*5*SnP_laneLengthInBytes);
     uint32_t *curData6 = (uint32_t *)(data+laneOffset*6*SnP_laneLengthInBytes);
     uint32_t *curData7 = (uint32_t *)(data+laneOffset*7*SnP_laneLengthInBytes);
-    const V256 *stateAsLanes = (const V256 *)states;
     const uint32_t *stateAsLanes32 = (const uint32_t*)states;
     unsigned int i;
 
@@ -374,7 +373,7 @@ void Xoodootimes8_ExtractAndAddBytes(const void *states, unsigned int instanceIn
     }
 
     while(sizeLeft >= SnP_laneLengthInBytes) {
-        *((uint32_t*)curOutput) = *((uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
+        *((uint32_t*)curOutput) = *((const uint32_t*)curInput) ^ statesAsLanes[laneIndex(instanceIndex, lanePosition)];
         sizeLeft -= SnP_laneLengthInBytes;
         lanePosition++;
         curInput += SnP_laneLengthInBytes;
@@ -392,14 +391,14 @@ void Xoodootimes8_ExtractAndAddBytes(const void *states, unsigned int instanceIn
 
 void Xoodootimes8_ExtractAndAddLanesAll(const void *states, const unsigned char *input, unsigned char *output, unsigned int laneCount, unsigned int laneOffset)
 {
-    const uint32_t *curInput0 = (uint32_t *)(input+laneOffset*0*SnP_laneLengthInBytes);
-    const uint32_t *curInput1 = (uint32_t *)(input+laneOffset*1*SnP_laneLengthInBytes);
-    const uint32_t *curInput2 = (uint32_t *)(input+laneOffset*2*SnP_laneLengthInBytes);
-    const uint32_t *curInput3 = (uint32_t *)(input+laneOffset*3*SnP_laneLengthInBytes);
-    const uint32_t *curInput4 = (uint32_t *)(input+laneOffset*4*SnP_laneLengthInBytes);
-    const uint32_t *curInput5 = (uint32_t *)(input+laneOffset*5*SnP_laneLengthInBytes);
-    const uint32_t *curInput6 = (uint32_t *)(input+laneOffset*6*SnP_laneLengthInBytes);
-    const uint32_t *curInput7 = (uint32_t *)(input+laneOffset*7*SnP_laneLengthInBytes);
+    const uint32_t *curInput0 = (const uint32_t *)(input+laneOffset*0*SnP_laneLengthInBytes);
+    const uint32_t *curInput1 = (const uint32_t *)(input+laneOffset*1*SnP_laneLengthInBytes);
+    const uint32_t *curInput2 = (const uint32_t *)(input+laneOffset*2*SnP_laneLengthInBytes);
+    const uint32_t *curInput3 = (const uint32_t *)(input+laneOffset*3*SnP_laneLengthInBytes);
+    const uint32_t *curInput4 = (const uint32_t *)(input+laneOffset*4*SnP_laneLengthInBytes);
+    const uint32_t *curInput5 = (const uint32_t *)(input+laneOffset*5*SnP_laneLengthInBytes);
+    const uint32_t *curInput6 = (const uint32_t *)(input+laneOffset*6*SnP_laneLengthInBytes);
+    const uint32_t *curInput7 = (const uint32_t *)(input+laneOffset*7*SnP_laneLengthInBytes);
     uint32_t *curOutput0 = (uint32_t *)(output+laneOffset*0*SnP_laneLengthInBytes);
     uint32_t *curOutput1 = (uint32_t *)(output+laneOffset*1*SnP_laneLengthInBytes);
     uint32_t *curOutput2 = (uint32_t *)(output+laneOffset*2*SnP_laneLengthInBytes);
@@ -409,7 +408,6 @@ void Xoodootimes8_ExtractAndAddLanesAll(const void *states, const unsigned char 
     uint32_t *curOutput6 = (uint32_t *)(output+laneOffset*6*SnP_laneLengthInBytes);
     uint32_t *curOutput7 = (uint32_t *)(output+laneOffset*7*SnP_laneLengthInBytes);
 
-    const V256 *stateAsLanes = (const V256 *)states;
     const uint32_t *stateAsLanes32 = (const uint32_t*)states;
     unsigned int i;
 
@@ -599,7 +597,7 @@ void Xooffftimes8_AddIs(unsigned char *output, const unsigned char *input, size_
         output += 32;
     }
    while ( byteLen >= 8 ) {
-        *((uint64_t*)output) ^= *((uint64_t*)input);
+        *((uint64_t*)output) ^= *((const uint64_t*)input);
         input += 8;
         output += 8;
         byteLen -= 8;
@@ -619,9 +617,9 @@ void Xooffftimes8_AddIs(unsigned char *output, const unsigned char *input, size_
 size_t Xooffftimes8_CompressFastLoop(unsigned char *k, unsigned char *x, const unsigned char *input, size_t length)
 {
     DeclareVars;
-    uint32_t    *k32 = (uint32_t*)k;
-    uint32_t    *x32 = (uint32_t*)x;
-    uint32_t    *i32 = (uint32_t*)input;
+    uint32_t       *k32 = (uint32_t*)k;
+    uint32_t       *x32 = (uint32_t*)x;
+    const uint32_t *i32 = (const uint32_t*)input;
     size_t      initialLength;
     V256        r04815926;
     V256        r5926a37b;
@@ -758,10 +756,10 @@ size_t Xooffftimes8_CompressFastLoop(unsigned char *k, unsigned char *x, const u
     x01 = XOR256(x01, SHUFFLE_LANES_RIGHT(x01, 1));
     x20 = XOR256(x20, SHUFFLE_LANES_RIGHT(x20, 1));
     x00 = _mm256_blend_epi32( x00, SHUFFLE_LANES_RIGHT(x01, 7), 0xAA);
-    x20 = _mm256_permutevar8x32_epi32( x20, *(V256*)shufflePack);
+    x20 = _mm256_permutevar8x32_epi32( x20, *(const V256*)shufflePack);
 
     x00 = XOR256(x00, *(V256*)&x32[0]);
-    x4 = XOR128(_mm256_castsi256_si128(x20), *(V128*)&x32[8]);
+    x4 = XOR128(_mm256_castsi256_si128(x20), *(const V128*)&x32[8]);
 
     STORE256u( *(V256*)&x32[0], x00);
     STORE128u( *(V128*)&x32[8], x4);
@@ -787,7 +785,7 @@ size_t Xooffftimes8_CompressFastLoop(unsigned char *k, unsigned char *x, const u
 size_t Xooffftimes8_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kRoll, unsigned char *output, size_t length)
 {
     DeclareVars;
-    const uint32_t  *k32 = (uint32_t*)kRoll;
+    const uint32_t  *k32 = (const uint32_t*)kRoll;
     uint32_t        *y32 = (uint32_t*)yAccu;
     uint32_t        *o32 = (uint32_t*)output;
     size_t      initialLength;

--- a/lib/low/Xoodoo/AVX512/Xoodoo-SIMD512.c
+++ b/lib/low/Xoodoo/AVX512/Xoodoo-SIMD512.c
@@ -233,7 +233,7 @@ void Xoodoo_OverwriteWithZeroes(void *state, unsigned int byteCount)
 void Xoodoo_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    memcpy(data, (unsigned char*)state+offset, length);
+    memcpy(data, (const unsigned char*)state+offset, length);
 #else
     #error "Not yet implemented"
 #endif
@@ -448,7 +448,7 @@ void Xoofff_AddIs(unsigned char *output, const unsigned char *input, size_t bitL
         output += 32;
     }
    while ( byteLen >= 8 ) {
-        *((uint64_t*)output) ^= *((uint64_t*)input);
+        *((uint64_t*)output) ^= *((const uint64_t*)input);
         input += 8;
         output += 8;
         byteLen -= 8;

--- a/lib/low/Xoodoo/SSE2/Xoodoo-SIMD128.c
+++ b/lib/low/Xoodoo/SSE2/Xoodoo-SIMD128.c
@@ -132,7 +132,7 @@ void Xoodoo_OverwriteWithZeroes(void *state, unsigned int byteCount)
 void Xoodoo_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    memcpy(data, (unsigned char*)state+offset, length);
+    memcpy(data, (const unsigned char*)state+offset, length);
 #else
     #error "Not yet implemented"
 #endif

--- a/lib/low/common/PlSnP-Fallback.inc
+++ b/lib/low/common/PlSnP-Fallback.inc
@@ -51,6 +51,7 @@ Please refer to PlSnP-documentation.h for more details.
 #define PlSnP_factor ((PlSnP_targetParallelism)/(PlSnP_baseParallelism))
 #define SnP_stateOffset (((SnP_stateSizeInBytes+(SnP_stateAlignment-1))/SnP_stateAlignment)*SnP_stateAlignment)
 #define stateWithIndex(i) ((unsigned char *)states+((i)*SnP_stateOffset))
+#define stateWithIndexConst(i) ((const unsigned char *)states+((i)*SnP_stateOffset))
 
 #define SnP_StaticInitialize            JOIN(SnP, _StaticInitialize)
 #define SnP_Initialize                  JOIN(SnP, _Initialize)
@@ -220,7 +221,7 @@ void PlSnP_ExtractLanesAll(const void *states, unsigned char *data, unsigned int
 
     for(i=0; i<PlSnP_factor; i++) {
         #if (PlSnP_baseParallelism == 1)
-            SnP_ExtractBytes(stateWithIndex(i), data, 0, laneCount*SnP_laneLengthInBytes);
+            SnP_ExtractBytes(stateWithIndexConst(i), data, 0, laneCount*SnP_laneLengthInBytes);
         #else
             SnP_ExtractLanesAll(stateWithIndex(i), data, laneCount, laneOffset);
         #endif
@@ -243,7 +244,7 @@ void PlSnP_ExtractAndAddLanesAll(const void *states, const unsigned char *input,
 
     for(i=0; i<PlSnP_factor; i++) {
         #if (PlSnP_baseParallelism == 1)
-            SnP_ExtractAndAddBytes(stateWithIndex(i), input, output, 0, laneCount*SnP_laneLengthInBytes);
+            SnP_ExtractAndAddBytes(stateWithIndexConst(i), input, output, 0, laneCount*SnP_laneLengthInBytes);
         #else
             SnP_ExtractAndAddLanesAll(stateWithIndex(i), input, output, laneCount, laneOffset);
         #endif


### PR DESCRIPTION
Kernel drivers are typically built with the flag that treats warnings as errors.  This PR cleans up those warnings.