### PR TITLE
Adding user provided EXTRA_CFLAGS/EXTRA_ASMFLAGS/EXTRA_LDFLAGS in the…

### DIFF
--- a/support/Build/ToTargetMakefile.xsl
+++ b/support/Build/ToTargetMakefile.xsl
@@ -159,10 +159,10 @@ SOURCES := $(SOURCES) </xsl:text>
 </xsl:text>
         <xsl:choose>
             <xsl:when test="local-name(.) = 's'">
-                <xsl:text>&#9;$(CC) $(INCLUDEFLAGS) $(ASMFLAGS) </xsl:text>
+                <xsl:text>&#9;$(CC) $(INCLUDEFLAGS) $(ASMFLAGS) $(EXTRA_ASMFLAGS) </xsl:text>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:text>&#9;$(CC) $(INCLUDEFLAGS) $(CFLAGS) </xsl:text>
+                <xsl:text>&#9;$(CC) $(INCLUDEFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) </xsl:text>
             </xsl:otherwise>
         </xsl:choose>
         <xsl:value-of select="@gcc"/>
@@ -228,7 +228,7 @@ UNAME_M := $(shell uname -m)
 </xsl:text>
 
     <xsl:if test="substring(@name, string-length(@name)-2, 3)='.so'">
-        <xsl:text>CFLAGS := $(CFLAGS) -fpic
+        <xsl:text>CFLAGS := $(CFLAGS) $(EXTRA_CFLAGS) -fpic
 </xsl:text>
     </xsl:if>
 
@@ -269,7 +269,7 @@ bin/</xsl:text>
         <xsl:when test="substring(@name, string-length(@name)-2, 3)='.so'">
             <xsl:text>&#9;mkdir -p $@.headers
 &#9;cp -f $(HEADERS) $@.headers/
-&#9;$(CC) -shared -o $@ $(OBJECTS) $(CFLAGS)
+&#9;$(CC) -shared -o $@ $(OBJECTS) $(CFLAGS) $(EXTRA_CFLAGS) $(EXTRA_LDFLAGS)
 </xsl:text>
         </xsl:when>
         <xsl:when test="substring(@name, string-length(@name)-5, 6)='.dylib'">
@@ -277,11 +277,11 @@ bin/</xsl:text>
 &#9;cp -f $(HEADERS) $@.headers/
 &#9;$(CC) -dynamiclib -install_name @rpath/</xsl:text>
         <xsl:value-of select="@name"/>
-        <xsl:text> $(CFLAGS) $(OBJECTS) -o $@
+        <xsl:text> $(CFLAGS) $(EXTRA_CFLAGS) $(EXTRA_LDFLAGS) $(OBJECTS) -o $@
 </xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:text>&#9;$(CC) -o $@ $(OBJECTS) $(CFLAGS)
+            <xsl:text>&#9;$(CC) -o $@ $(OBJECTS) $(CFLAGS) $(EXTRA_CFLAGS) $(EXTRA_LDFLAGS)
 </xsl:text>
         </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
… targets Makefile to improve cross-compilation.

This somehow extends and attempts to generically resolve the issues discussed in issue #119.

This adds `EXTRA_CFLAGS`, `EXTRA_ASMFLAGS` and `EXTRA_LDFLAGS` to the compilation toolchain. This allows for better cross-compilation handling for non-x86 platforms on x86 hosts (and even for incompatible x86 platforms on other x86 platforms). This works because the extra flags are **appended** to the compilation invocations, meaning they will override the previous flags (hence overriding `-march` and `-mtune` allows to finely tune the target). This append only feature of the extra flags should make them transparent to the current compilation flow when they are empty.

For instance, compiling unit tests for `ARMv6` with the `arm-linux-gnueabi-gcc` cross-compiler can be invoked with (tested on a Debian distro):
```
make clean && CC="arm-linux-gnueabi-gcc" EXTRA_CFLAGS="-march=armv6 -mtune=arm1136j-s" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make ARMv6/UnitTests
```

The `-static` linker flags allows to get a static binary that can be executed with a static `qemu` ARM emulator on the x86 host:
```
$ file bin/ARMv6/UnitTests 
bin/ARMv6/UnitTests: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, BuildID[sha1]=9875770d4ca10b1ce877dca7e1e74c9ecb89ede3, for GNU/Linux 3.2.0, not stripped

# Executing with Qemu static emulator:
$ ./bin/ARMv6/UnitTests -a
* Keccak-p[200]: 32-bit optimized ARM assembler implementation
    - OK
* Keccak-p[400]: 32-bit optimized ARM assembler implementation
    - OK
* Keccak-p[800]: 32-bit optimized ARM assembler implementation
    - OK
...
```

Although this has not been tested on all the possible targets, this paves the way to generic cross-compilation and extended CI on x86 platforms (possibly through github actions), which is a WIP.