### PR TITLE
Usage documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.inc": "c"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.associations": {
-    "*.inc": "c"
-  }
-}

--- a/README.markdown
+++ b/README.markdown
@@ -106,6 +106,10 @@ The XKCP also provides some standalone implementations, including:
 * the reference code of KangarooTwelve in Python in [`Standalone/KangarooTwelve/Python/`](Standalone/KangarooTwelve/Python/).
 
 
+# Is there example code?
+
+Yes, there is example code for using many cryptographic functions of the XKCP. You can find them in the [`usage-example.md`](usage-example.md) file.
+
 
 # Under which license is the XKCP distributed?
 

--- a/usage-example.md
+++ b/usage-example.md
@@ -909,8 +909,6 @@ int main() {
 
 </details>
 
-...
-
 ## Xoofff
 
 Xoofff is similar to Kravatte, it's also built on top of the Farfalle construction, however,

--- a/usage-example.md
+++ b/usage-example.md
@@ -391,4 +391,10 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
 
 # {{Other types of functions}}
 
+- [ ]  Ketje
+- [ ]  Keyak
+- [ ]  Kravatte and its modes
+- [ ]  Xoofff and its modes
+- [ ]  Xoodyak
+
 ...

--- a/usage-example.md
+++ b/usage-example.md
@@ -391,8 +391,6 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
 
 # {{Other types of functions}}
 
-- [ ]  Ketje
-- [ ]  Keyak
 - [ ]  Kravatte and its modes
 - [ ]  Xoofff and its modes
 - [ ]  Xoodyak

--- a/usage-example.md
+++ b/usage-example.md
@@ -115,9 +115,13 @@ For more information on how to use the FIPS 202 functions, see the `SimpleFIPS20
 Keccak-p permutation reduced to 12 rounds (instead of 24), so about twice faster. 
 They are based on the `Sponge construction`, and the `Keccak-p[1600, 12]` permutation.
 
+[//]: # (TODO: add example)
+
 ## KangarooTwelve
 `KangarooTwelve`, or `K12`, is a family of XOFs, based on the `TurboSHAKE128`, hence it also uses the `Keccak-p[1600, 12]` permutation.
 On high-end platforms, it can exploit a high degree of parallelism, whether using multiple cores or the SIMD instruction set of modern processors.
+
+[//]: # (TODO: add example)
 
 # {{Other types of functions}}
 

--- a/usage-example.md
+++ b/usage-example.md
@@ -49,8 +49,8 @@ The following steps illustrate how to do that:
       const unsigned char *input = 
               (const unsigned char *) "The random message to hash";
 
-      int OUTPUT_LENGTH = 32;
-      unsigned char output[OUTPUT_LENGTH];
+      int outputByteLen = 32;
+      unsigned char output[outputByteLen];
       
       int result = SHA3_256(output, input, strlen((const char *) input));
       
@@ -58,7 +58,7 @@ The following steps illustrate how to do that:
       assert(result == 0);
       
       // printing the hash in hexadecimal format
-      for (int i = 0; i < OUTPUT_LENGTH; i++)
+      for (int i = 0; i < outputByteLen; i++)
           printf("\\x%02x", output[i]);
       printf("\n");
 
@@ -77,9 +77,9 @@ The following steps illustrate how to do that:
     #include "KeccakHash.h"
 
     int main() {
-        const int INPUT_CHUNKS_COUNT = 4;
+        const int inputChunksCount = 4;
 
-        const unsigned char *input[INPUT_CHUNKS_COUNT] = {
+        const unsigned char *input[inputChunksCount] = {
             (const unsigned char *) "Hello, ",
             (const unsigned char *) "this is ",
             (const unsigned char *) "my custom ",
@@ -93,21 +93,21 @@ The following steps illustrate how to do that:
         result = Keccak_HashInitialize_SHA3_256(&hi);
         assert(result == KECCAK_SUCCESS);
 
-        for (int i = 0; i < INPUT_CHUNKS_COUNT; i++) {
+        for (int i = 0; i < inputChunksCount; i++) {
             // feed the input in chunks
             Keccak_HashUpdate(&hi, input[i], strlen((const char *) input[i]) * 8);
             assert(result == KECCAK_SUCCESS);
         }
 
-        int OUTPUT_LENGTH = 32;
-        unsigned char output[OUTPUT_LENGTH];
+        int outputByteLen = 32;
+        unsigned char output[outputByteLen];
 
         // get the output
         result = Keccak_HashFinal(&hi, output);
         assert(result == KECCAK_SUCCESS);
 
         // printing the hash in hexadecimal format
-        for (int i = 0; i < OUTPUT_LENGTH; i++)
+        for (int i = 0; i < outputByteLen; i++)
             printf("\\x%02x", output[i]);
         printf("\n"); 
         
@@ -129,15 +129,15 @@ The following steps illustrate how to do that:
         const unsigned char *input = (const unsigned char *) "The random message to hash";
 
         // you can choose any output length
-        int OUTPUT_LENGTH = 64;
-        unsigned char output[OUTPUT_LENGTH];
+        int outputByteLen = 64;
+        unsigned char output[outputByteLen];
 
-        int result = SHAKE128(output, OUTPUT_LENGTH, input, strlen((const char *) input));
+        int result = SHAKE128(output, outputByteLen, input, strlen((const char *) input));
         // returning 0 means success
         assert(result == 0);
 
         // printing the hash in hexadecimal format
-        for (int i = 0; i < OUTPUT_LENGTH; i++)
+        for (int i = 0; i < outputByteLen; i++)
            printf("\\x%02x", output[i]);
         printf("\n");
 
@@ -173,32 +173,32 @@ The following steps illustrate how to do that:
         assert(result == KECCAK_SUCCESS);
 
         // choose the output chunk length
-        const int OUTPUT_CHUNK_LENGTH = 16;
-        unsigned char chunk[OUTPUT_CHUNK_LENGTH];
+        const int outputChunkByteLen = 16;
+        unsigned char chunk[outputChunkByteLen];
 
         // choose the number of output chunks
-        const int OUTPUT_CHUNKS_COUNT = 4;
+        const int outputChunksCount = 4;
 
         // initialize the full output
-        const int FULL_OUTPUT_LENGTH = OUTPUT_CHUNK_LENGTH * OUTPUT_CHUNKS_COUNT;
-        unsigned char output[FULL_OUTPUT_LENGTH];
+        const int fullOutputByteLen = outputChunkByteLen * outputChunksCount;
+        unsigned char output[fullOutputByteLen];
 
-        for (int i = 0; i < OUTPUT_CHUNKS_COUNT; i++) {
-            result = Keccak_HashSqueeze(&hi, chunk, OUTPUT_CHUNK_LENGTH * 8);
+        for (int i = 0; i < outputChunksCount; i++) {
+            result = Keccak_HashSqueeze(&hi, chunk, outputChunkByteLen * 8);
             assert(result == KECCAK_SUCCESS);
 
             // incrementally build the output, like writing to a file.
             // for simplicity, we use `memcpy` in this example:
-            memcpy(output + (i * OUTPUT_CHUNK_LENGTH), chunk, OUTPUT_CHUNK_LENGTH);
+            memcpy(output + (i * outputChunkByteLen), chunk, outputChunkByteLen);
         }
 
         // printing the output chunk in hexadecimal format
-        for (int i = 0; i < FULL_OUTPUT_LENGTH; i++)
+        for (int i = 0; i < fullOutputByteLen; i++)
             printf("\\x%02x", output[i]);
         printf("\n");
 
-        return 0;
-}
+        // ...
+    }
    ```
 
 </details>
@@ -229,17 +229,17 @@ We will give usage examples of the `TurboSHAKE128` function, but the same applie
         const unsigned char *input = (const unsigned char *) "The random message to hash";
 
         // you can choose any output length
-        int OUTPUT_LENGTH = 512;
-        unsigned char output[OUTPUT_LENGTH];
+        int outputByteLen = 512;
+        unsigned char output[outputByteLen];
 
         // choose a domain separation in the range `[0x01, 0x02, .. , 0x7F]`
         unsigned char domain = 0x1F;
 
-        int result = TurboSHAKE(256, input, strlen((const char *) input), domain, output, OUTPUT_LENGTH);
+        int result = TurboSHAKE(256, input, strlen((const char *) input), domain, output, outputByteLen);
         assert(result == 0);  // returning 0 means success
 
         // printing the hash in hexadecimal format
-        for (int i = 0; i < OUTPUT_LENGTH; i++)
+        for (int i = 0; i < outputByteLen; i++)
            printf("\\x%02x", output[i]);
         printf("\n");
 
@@ -275,27 +275,27 @@ We will give usage examples of the `TurboSHAKE128` function, but the same applie
         assert(result == 0);
 
         // choose the output chunk length
-        const int OUTPUT_CHUNK_LENGTH = 16;
-        unsigned char chunk[OUTPUT_CHUNK_LENGTH];
+        const int outputChunkByteLen = 16;
+        unsigned char chunk[outputChunkByteLen];
 
         // choose the number of output chunks
-        const int OUTPUT_CHUNKS_COUNT = 4;
+        const int outputChunksCount = 4;
 
         // initialize the full output
-        const int FULL_OUTPUT_LENGTH = OUTPUT_CHUNK_LENGTH * OUTPUT_CHUNKS_COUNT;
-        unsigned char output[FULL_OUTPUT_LENGTH];
+        const int fullOutputByteLen = outputChunkByteLen * outputChunksCount;
+        unsigned char output[fullOutputByteLen];
 
-        for (int i = 0; i < OUTPUT_CHUNKS_COUNT; i++) {
-            result = TurboSHAKE_Squeeze(&tsi, output, OUTPUT_CHUNK_LENGTH);
+        for (int i = 0; i < outputChunksCount; i++) {
+            result = TurboSHAKE_Squeeze(&tsi, output, outputChunkByteLen);
             assert(result == 0);
 
             // incrementally build the output, like writing to a file.
             // for simplicity, we use `memcpy` in this example:
-            memcpy(output + (i * OUTPUT_CHUNK_LENGTH), chunk, OUTPUT_CHUNK_LENGTH);
+            memcpy(output + (i * outputChunkByteLen), chunk, outputChunkByteLen);
         }
 
         // printing the output chunk in hexadecimal format
-        for (int i = 0; i < FULL_OUTPUT_LENGTH; i++)
+        for (int i = 0; i < fullOutputByteLen; i++)
             printf("\\x%02x", output[i]);
         printf("\n");
 
@@ -319,14 +319,14 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
     int main() {
         const unsigned char *input = (const unsigned char *) "The random message to hash";
 
-        const int OUTPUT_LENGTH = 64;
-        unsigned char output[OUTPUT_LENGTH];
+        const int outputByteLen = 64;
+        unsigned char output[outputByteLen];
 
-        int result = KangarooTwelve(input, strlen((const char *) input), output, OUTPUT_LENGTH, NULL, 0);
+        int result = KangarooTwelve(input, strlen((const char *) input), output, outputByteLen, NULL, 0);
         assert(result == 0);  // returning 0 means success
 
         // printing the hash in hexadecimal format
-        for (int i = 0; i < OUTPUT_LENGTH; i++)
+        for (int i = 0; i < outputByteLen; i++)
            printf("\\x%02x", output[i]);
         printf("\n");
 
@@ -343,9 +343,9 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
     #include "KangarooTwelve.h"
 
     int main() {
-        const int INPUT_CHUNKS_COUNT = 4;
+        const int inputChunksCount = 4;
 
-        const unsigned char *input[INPUT_CHUNKS_COUNT] = {
+        const unsigned char *input[inputChunksCount] = {
             (const unsigned char *) "The ",
             (const unsigned char *) "random ",
             (const unsigned char *) "message ",
@@ -357,7 +357,7 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
         int result = KangarooTwelve_Initialize(&kti, 0);
         assert(result == 0);
 
-        for (int i = 0; i < INPUT_CHUNKS_COUNT; i++) {
+        for (int i = 0; i < inputChunksCount; i++) {
             result = KangarooTwelve_Update(&kti, input[i], strlen((const char *) input[i]));
             assert(result == 0);
         }
@@ -365,30 +365,29 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
         result = KangarooTwelve_Final(&kti, NULL, NULL, 0);
         assert(result == 0);
 
-        const int OUTPUT_CHUNK_LENGTH = 16;
-        unsigned char chunk[OUTPUT_CHUNK_LENGTH];
+        const int outputChunkByteLen = 16;
+        unsigned char chunk[outputChunkByteLen];
 
-        const int OUTPUT_CHUNKS_COUNT = 4;
+        const int outputChunksCount = 4;
 
-        const int FULL_OUTPUT_LENGTH = OUTPUT_CHUNK_LENGTH * OUTPUT_CHUNKS_COUNT;
-        unsigned char output[FULL_OUTPUT_LENGTH];
+        const int fullOutputByteLen = outputChunkByteLen * outputChunksCount;
+        unsigned char output[fullOutputByteLen];
 
-        for (int i = 0; i < OUTPUT_CHUNKS_COUNT; i++) {
-            result = KangarooTwelve_Squeeze(&kti, chunk, OUTPUT_CHUNK_LENGTH);
+        for (int i = 0; i < outputChunksCount; i++) {
+            result = KangarooTwelve_Squeeze(&kti, chunk, outputChunkByteLen);
             assert(result == 0);
 
-            memcpy(output + (i * OUTPUT_CHUNK_LENGTH), chunk, OUTPUT_CHUNK_LENGTH);
+            memcpy(output + (i * outputChunkByteLen), chunk, outputChunkByteLen);
         }
 
         // printing the output chunk in hexadecimal format
-        for (int i = 0; i < FULL_OUTPUT_LENGTH; i++)
+        for (int i = 0; i < fullOutputByteLen; i++)
             printf("\\x%02x", output[i]);
         printf("\n");
 
         // ...
     }
    ```
-
 
 # {{Other types of functions}}
 

--- a/usage-example.md
+++ b/usage-example.md
@@ -1,10 +1,10 @@
 In this guide, we will provide examples of using the high-level API, with less emphasis on
 the low-level implementation, since XKCP abstracts the low-level implementation from the user.
 
-Before proceeding with the usage example, please make sure that you have built the XKCP library as described in the [README](../README.md).
+Before proceeding with the usage example, please make sure that you have built the XKCP library as described in the [README](../README.md)
 and included it in your C/C++ project.
 
-# Hashing and Extendable output functions (XOFs)
+# Hashing and extendable output functions (XOFs)
 
 ## FIPS 202
 
@@ -13,21 +13,21 @@ The functions are:
 
 ### Hash functions
 
-A hash function is a function on binary data (i.e., bit strings) for which the length of the output is fixed. <br>
+A hash function is a function of binary data (i.e., of a bit string) for which the length of the output is fixed.
 The input to a hash function is called the _message_, and the output is called the _digest_ or _hash value_.
 
 NIST standardized the following hash functions in FIPS 202:
 
-- `SHA3_224`
-- `SHA3_256`
-- `SHA3_384`
-- `SHA3_512`
+- `SHA3-224`
+- `SHA3-256`
+- `SHA3-384`
+- `SHA3-512`
 
 The suffix `224`, `256`, `384`, and `512` indicate the fixed length of the `digest` in bits.
 
 ### Extendable output functions (XOFs)
 
-A XOF is a function on bit strings, also called _messages_, in which the output can be extended to any desired length. <br>
+A XOF is a function of a bit string, also called _message_, but for which the output can be extended to any desired length.
 
 NIST standardized the following XOFs in FIPS 202, marking them as the first XOFs to be standardized by NIST.
 
@@ -38,10 +38,10 @@ The suffix `128` and `256` indicates the desired security level of the function.
 
 ### Usage
 
-To use any of them in your C/C++ project, you have to first build the FIPS202 library, and include it in your project.
+To use any of them in your C/C++ project, you have to first build the XKCP library, and include it in your project.
 The following steps illustrate how to do that:
 
-#### Example of using the `SHA3_256` hash function
+#### Example of using the `SHA3-256` hash function
 
 <details open>
     <summary>Simple usage</summary>
@@ -77,8 +77,9 @@ int main() {
     <summary>Advanced: Chunked input</summary>
     Sometimes, the input of your function is too long to be stored in memory and passed to the function at once, 
     think of a big file for example. In such cases, you can feed the input as chunks to the hash function, and at the end, 
-    get the output at once or in chunks as well (We'll show an example of that later, with the SHAKE128 XOF).
-    
+    get the output at once or in chunks as well.
+    (We'll show an example of that later, with the SHAKE128 XOF.)
+
    ```c
     #include "KeccakHash.h"
 
@@ -220,8 +221,8 @@ Keccak-p permutation reduced to 12 rounds (instead of 24), so about twice faster
 They are based on the `Sponge construction`, and the `Keccak-p[1600, 12]` permutation.
 
 There are 2 main functions in this family:
-- TurboSHAKE128
-- TurboSHAKE256
+- `TurboSHAKE128`
+- `TurboSHAKE256`
 
 The suffix `128` and `256` indicates the desired security level of the function.
 
@@ -560,10 +561,10 @@ while offering incremental properties on the input and output, helping in speedi
     
 Those examples can be adapted to support multiple input multiple output as well, by using a sequence of `Kra` and `Vatte` calls.
 
-### SANE mode (Authenticated Encryption)
+### Kravatte-SANE authenticated encryption
 
-SANE is an authenticated encryption scheme supporting sessions, the tag for the message n authenticates
-the full history of the session up to that point, i.e. the messages 1, 2, ..., n. <br>
+SANE is a nonce-based authenticated encryption scheme supporting sessions, the tag for the message _n_ authenticates
+the full history of the session up to that point, i.e., the messages 1, 2, ..., _n_.
 
 <details open>
    <summary>Authenticated Encryption: conversation example</summary>
@@ -594,6 +595,7 @@ int main() {
 
     // choose the nonce. it must be the same for both ksiEnc and ksiDec
     const int nonceBitLen = 128;
+    // important: the nonce must be a different value at every use!
     BitSequence nonce[nonceBitLen] = "alksjdfo2300a9sd";
 
     BitSequence tagEnc[Kravatte_SANE_TagLength];
@@ -678,15 +680,16 @@ int main() {
 
 </details>
 
-### SANSE mode (Authenticated Encryption)
+### Kravatte-SANSE authenticated encryption
 
-Like SANE, SANE is an authenticated encryption scheme supporting sessions, the tag for the message n authenticates
-the full history of the session up to that point, i.e. the messages 1, 2, ..., n. <br>
+Like SANE, SANE is an authenticated encryption scheme supporting sessions, the tag for the message _n_ authenticates
+the full history of the session up to that point, i.e. the messages 1, 2, ..., _n_.
 
-However, SANSE is a nonce-misuse resistant version of SANE, and doesn't require the user to provide a nonce.
+However, SANSE is a nonce-misuse resistant version of SANE.
 Instead, it uses a nonce internally, and the user only needs to provide a key.
 
-For better security, a user can include a nonce in the metadata of the first message.
+Equal plaintext-associated data pairs can still be detected from equal ciphertexts, so it is best to make sure the associated data is unique per session.
+For instance, a user can include a nonce in the associated data of the first message of the session.
 
 <!-- TODO: clarify more about nonce misuse resistant of SANSE? -->
 
@@ -796,9 +799,9 @@ int main() {
 
 </details>
 
-### WBC mode (Wide Block Cipher)
+### Kravatte-WBC wide block cipher
 
-WBC is a wide block cipher mode, Built on top of the Farfalle construction and the Feistel network.
+WBC is a wide block cipher mode, built as a Feistel network.
 It can be used to encrypt a message of any length, and produce a ciphertext of the same length.
 
 <details open>
@@ -846,9 +849,9 @@ int main() {
 
 </details>
 
-### WBC-AE mode (Wide Block Cipher Authenticated Encryption)
+### Kravatte-WBC-AE authenticated encryption
 
-WBC-AE is an Authenticated Encryption mode, Built on top of the WBC mode.
+WBC-AE is an authenticated encryption mode, built on top of the WBC mode.
 
 <details open>
    <summary>Simple encryption/decryption example with authentication</summary>
@@ -911,8 +914,8 @@ int main() {
 
 ## Xoofff
 
-Xoofff is similar to Kravatte, it's also built on top of the Farfalle construction, however,
-it uses the Xoodoo permutation as primitive instead of the Keccak-p used in Kravatte, which makes it more suitable for constrained environments.
+Xoofff is similar to Kravatte, it's also built on top of the Farfalle construction.
+However, it uses the Xoodoo permutation as primitive instead of the Keccak-p used in Kravatte, which makes it more suitable for constrained environments.
 
 Xoofff has an API similar to Kravatte, so the examples of Kravatte can be adapted to use Xoofff.
 In the following, we will give the differences between the APIs of Kravatte and Xoofff.
@@ -931,7 +934,7 @@ One can use the below conversion tables to adapt the examples of Kravatte to use
 | Output Retrieval Function | Vatte                   | Xoofff_Expand         |
 | Flag for Last Part        | KRAVATTE_FLAG_LAST_PART | Xoofff_FlagLastPart   |
 
-### SANE mode (Authenticated Encryption)
+### Xoofff-SANE authenticated encryption
 
 | Feature             | Kravatte SANE            | Xoofff SANE           |
 | ------------------- | ------------------------ | --------------------- |
@@ -942,7 +945,7 @@ One can use the below conversion tables to adapt the examples of Kravatte to use
 | Unwrapping Function | Kravatte_SANE_Unwrap     | XoofffSANE_Unwrap     |
 | Tag Length          | Kravatte_SANE_TagLength  | XoofffSANE_TagLength  |
 
-### SANSE mode (Authenticated Encryption)
+### Xoofff-SANSE authenticated encryption
 
 | Feature             | Kravatte SANSE            | Xoofff SANSE           |
 | ------------------- | ------------------------- | ---------------------- |
@@ -953,7 +956,7 @@ One can use the below conversion tables to adapt the examples of Kravatte to use
 | Unwrapping Function | Kravatte_SANSE_Unwrap     | XoofffSANSE_Unwrap     |
 | Tag Length          | Kravatte_SANSE_TagLength  | XoofffSANSE_TagLength  |
 
-### WBC
+### Xoofff-WBC wide block cipher
 
 | Feature           | Kravatte WBC            | Xoofff WBC           |
 | ----------------- | ----------------------- | -------------------- |
@@ -963,7 +966,7 @@ One can use the below conversion tables to adapt the examples of Kravatte to use
 | Encipher Function | Kravatte_WBC_Encipher   | XoofffWBC_Encipher   |
 | Decipher Function | Kravatte_WBC_Decipher   | XoofffWBC_Decipher   |
 
-### WBC-AE
+### Xoofff-WBC-AE authenticated encryption
 
 | Feature           | Kravatte WBC-AE           | Xoofff WBC-AE          |
 | ----------------- | ------------------------- | ---------------------- |
@@ -985,9 +988,9 @@ The mode of operation on top of Xoodoo is called Cyclist.
 
 Xoodoo can be used in 2 modes, Hashed mode and Keyed mode. We will provide examples for both modes separately, as well as an example for using them together.
 
-### Hashed mode
+### Hash mode
 
-In Hashed mode, Xoodoo can absorb an arbitrary length input, and produce an arbitrary length output.
+In hash mode, Xoodoo can absorb an arbitrary length input, and produce an arbitrary length output.
 
 <details open>
    <summary>Simple usage: single input single output</summary>
@@ -1144,7 +1147,7 @@ void multipleInputMultipleOutput()
 In keyed mode, Xoodyak can do stream encryption, message authentication code (MAC)
 computation and authenticated encryption.
 
-Note that in the following examples, we will use the same `messages` array used in the above "Hashed Mode" examples.
+Note that in the following examples, we will use the same `messages` array used in the above "Hash mode" examples.
 
 <details open>
     <summary>Simple encryption/decryption</summary>
@@ -1164,6 +1167,7 @@ Xoodyak_Instance decInstance;
     Xoodyak_Initialize(&decInstance, key, 16, NULL, 0, NULL, 0);
 
     // choose any nonce
+    // important: the nonce must be a different value at every use!
     unsigned char nonce[16] = "#dojd983&72-21!@";
 
     // encryption and decryption instances must absorb the same nonce
@@ -1209,6 +1213,7 @@ void authenticatedEncryption() {
     Xoodyak_Initialize(&decInstance, key, 16, NULL, 0, NULL, 0);
 
     // choose any nonce
+    // important: the nonce must be a different value at every use (or the metadata of the first message must be unique).
     unsigned char nonce[16] = "#dojd983&72-21!@";
 
     // encryption and decryption instances must absorb the same nonce
@@ -1238,7 +1243,7 @@ void authenticatedEncryption() {
     // 4. send the encrypted message and the tag over the wire:
 
     // on the wire:
-    // CAUTION: temper with the encrypted message (flip a bit) by uncommenting
+    // CAUTION: tamper with the encrypted message (flip a bit) by uncommenting
     // the following line and the tags will not match -> Authentication insured.
     // encrypted[0] ^= 1;
 
@@ -1287,6 +1292,7 @@ void sessionAuthenticatedEncryption() {
     Xoodyak_Initialize(&bobInstance, key, 16, NULL, 0, NULL, 0);
 
     // choose any nonce
+    // important: the nonce must be a different value at every use (or the metadata of the first message must be unique).
     unsigned char nonce[16] = "#dojd983&72-21!@";
 
     // alice and bob instances must absorb the same nonce
@@ -1572,9 +1578,9 @@ void authenticatedEncryptionWithRatchet() {
 </details>
 
 
-### Combining Hashed and Keyed modes
+### Combining hash and keyed modes
 
-A key exchange protocol, such as Diffie-Hellman or variant, results in a common secret that usually requires further derivation before being used as a symmetric secret key. To do this with a Xoodyak, we can first use it in hash mode to process the common secret, and then use the derived key with Xoodyak in Keyed mode.
+A key exchange protocol, such as Diffie-Hellman or variant, results in a common secret that usually requires further derivation before being used as a symmetric secret key. To do this with a Xoodyak, we can first use it in hash mode to process the common secret, and then use the derived key with Xoodyak in keyed mode.
 
 An example of such usage is given below. Note that we're not focusing on the details on the Diffie-Hellman key exchange, but rather on how to use Xoodyak in Hashed and Keyed modes together.
 

--- a/usage-example.md
+++ b/usage-example.md
@@ -1,20 +1,40 @@
-In this guide, we will provide examples of using the high-level API, 
-with less emphasis on the low-level implementation. When working with XKCP, 
-the low-level implementation is abstracted from the user.
+In this guide, we will provide examples of using the high-level API, with less emphasis on 
+the low-level implementation, since XKCP abstracts the low-level implementation from the user.
 
-# Hashing
+# Hashing and Extendable output functions (XOFs)
 
 ## FIPS 202
-Those are the NIST approved SHA-3 functions. They are based on the sponge construction, and the Keccak-p permutation.
+Those are the NIST approved SHA-3 functions. They are based on the `Sponge construction`, and the `Keccak-p[1600, 24]` permutation.
 The functions are:
 
 ### Hash functions
+A hash function is a function on binary data (i.e., bit strings) for which the length of the output is fixed. <br> 
+The input to a hash function is called the _message_, and the output is called the _digest_ or _hash value_. 
+
+NIST standardized the following hash functions in FIPS 202:
 - `SHA3_224`
 - `SHA3_256`
 - `SHA3_384`
 - `SHA3_512`
 
-To use any of them in your C/C++ project, follow the steps below:
+The suffix `224`, `256`, `384`, and `512` indicate the fixed length of the `digest` in bits.
+
+[//]: # (TODO: verify the above statement)
+
+### Extendable output functions (XOFs)
+A XOF is a function on bit strings, also called _messages_, in which the output can be extended to any desired length. <br>
+
+NIST standardized the following XOFs in FIPS 202, marking them as the first XOFs to be standardized by NIST.
+- `SHAKE128`
+- `SHAKE256`
+
+The suffix `128` and `256` indicates the desired security level of the function.
+
+### Usage
+
+To use any of them in your C/C++ project, you have to first build the FIPS202 library, and include it in your project.
+The following steps illustrate how to do that:
+
 1. From `LowLevel.build`, choose your low level implementation, it has to be one for `Keccak-p[1600]`  
 since the FIPS 202 functions are based on the `Keccak-p 1600`. In the following,
 we will use the unoptimized reference implementation `K1600-ref-64bits`.
@@ -26,28 +46,10 @@ more information about the high-level targets can be found in the `HighLevel.bui
 3. From the root of the XKCP repository, run `make FIPS202.a`
 4. In `bin` you will find the static library `FIPS202.a`, and the corresponding headers directory `FIPS202.a.headers`.
 You can copy those to your project directory.
-5. In your C/C++ main file, include the header `#include "FIPS202.a.headers/SimpleFIPS202.h"`
-6. Use the functions in your code! In the following example, we will use `SHA3_256`:
-    ```c
-    // your input message
-    const unsigned char *input = 
-            (const unsigned char *) "The random message to hash";
-
-    // the output that will contain the hash
-    unsigned char output[32];
-
-    int result = SHA3_256(output, input, (const char *) input));
-
-    // returning 0 means success
-    assert(result == 0);
-
-    // printing the hash in hexadecimal format
-    for (int i = 0; i < 32; i++) {
-        printf("%02x", output[i]);
-    }
-    ```
-7. Before executing the code, you have to compile the code with the static library `FIPS202.a`. 
-When using `gcc`, this step might look like this:
+5. In your C/C++ main file, include the header `#include "FIPS202.a.headers/SimpleFIPS202.h"
+6. You are ready to use the FIPS 202 functions in your code. See below for an example of using the `SHA3_256` and `SHAKE128` functions.
+7. Before executing the code, you have to compile the code with the static library `FIPS202.a`.
+   When using `gcc`, this step might look like this:
     ```bash
     gcc main.c FIPS202_reference.a;
     ```
@@ -56,8 +58,67 @@ When using `gcc`, this step might look like this:
     ./a.out
     ```
 
-### Extendable output functions (XOFs)
-- `SHAKE128`
-- `SHAKE256`
+#### Example of using the `SHA3_256` hash function
+    
+Add the following code to your C/C++ main file:
 
-[//]: # (TODO: add example for XOFs)
+```c
+// your input message
+const unsigned char *input = 
+        (const unsigned char *) "The random message to hash";
+
+int OUTPUT_LENGTH = 32;
+unsigned char output[OUTPUT_LENGTH];
+
+int result = SHA3_256(output, input, strlen((const char *) input));
+
+// returning 0 means success
+assert(result == 0);
+
+// printing the hash in hexadecimal format
+for (int i = 0; i < OUTPUT_LENGTH; i++)
+    printf("\\x%02x", output[i]);
+ 
+printf("\n");
+```
+
+#### Example of using the `SHAKE128` XOF
+
+Add the following code to your C/C++ main file:
+
+```c
+ // your input message
+ const unsigned char *input = 
+         (const unsigned char *) "The random message to hash";
+
+// you can choose any output length
+int OUTPUT_LENGTH = 64;
+
+ unsigned char output[OUTPUT_LENGTH];
+
+ int result = SHAKE128(output, OUTPUT_LENGTH, input, strlen((const char *) input));
+
+ // returning 0 means success
+ assert(result == 0);
+
+ // printing the hash in hexadecimal format
+ for (int i = 0; i < OUTPUT_LENGTH; i++)
+    printf("\\x%02x", output[i]);
+ 
+ printf("\n");
+```
+
+For more information on how to use the FIPS 202 functions, see the `SimpleFIPS202.h` header file.
+
+## TurboSHAKE
+`TurboSHAKE` is a family of fast and secure XOFs. These are just like the SHAKE functions of FIPS 202, but with the 
+Keccak-p permutation reduced to 12 rounds (instead of 24), so about twice faster. 
+They are based on the `Sponge construction`, and the `Keccak-p[1600, 12]` permutation.
+
+## KangarooTwelve
+`KangarooTwelve`, or `K12`, is a family of XOFs, based on the `TurboSHAKE128`, hence it also uses the `Keccak-p[1600, 12]` permutation.
+On high-end platforms, it can exploit a high degree of parallelism, whether using multiple cores or the SIMD instruction set of modern processors.
+
+# {{Other types of functions}}
+
+...

--- a/usage-example.md
+++ b/usage-example.md
@@ -273,7 +273,7 @@ We will give usage examples of the `TurboSHAKE128` function, but the same applie
         TurboSHAKE_Instance tsi;
 
         // initialize the turboSHAKE instance
-        int result = TurboSHAKE_Initialize(&tsi, 256);
+        int result = TurboSHAKE128_Initialize(&tsi);
         assert(result == 0);
 
         // feed the input

--- a/usage-example.md
+++ b/usage-example.md
@@ -919,7 +919,7 @@ it uses the Xoodoo permutation as primitive instead of the Keccak-p used in Krav
 Xoofff has an API similar to Kravatte, so the examples of Kravatte can be adapted to use Xoofff.
 In the following, we will give the differences between the APIs of Kravatte and Xoofff.
 
-One can use the below to adapt the examples of Kravatte to use Xoofff.
+One can use the below conversion tables to adapt the examples of Kravatte to use Xoofff.
 
 ### Basic usages
 

--- a/usage-example.md
+++ b/usage-example.md
@@ -1,0 +1,63 @@
+In this guide, we will provide examples of using the high-level API, 
+with less emphasis on the low-level implementation. When working with XKCP, 
+the low-level implementation is abstracted from the user.
+
+# Hashing
+
+## FIPS 202
+Those are the NIST approved SHA-3 functions. They are based on the sponge construction, and the Keccak-p permutation.
+The functions are:
+
+### Hash functions
+- `SHA3_224`
+- `SHA3_256`
+- `SHA3_384`
+- `SHA3_512`
+
+To use any of them in your C/C++ project, follow the steps below:
+1. From `LowLevel.build`, choose your low level implementation, it has to be one for `Keccak-p[1600]`  
+since the FIPS 202 functions are based on the `Keccak-p 1600`. In the following,
+we will use the unoptimized reference implementation `K1600-ref-64bits`.
+You can find more information about available low-level implementations in the `LowLevel.build` file.
+2. In `HOWTO-customize.build`, add the following line:
+```<target name="FIPS202.a" inherits="FIPS202 KeccakP-1600-reference" />```
+Where `FIPS202` is the name of the high-level target that includes the FIPS 202 functions, 
+more information about the high-level targets can be found in the `HighLevel.build` file.
+3. From the root of the XKCP repository, run `make FIPS202.a`
+4. In `bin` you will find the static library `FIPS202.a`, and the corresponding headers directory `FIPS202.a.headers`.
+You can copy those to your project directory.
+5. In your C/C++ main file, include the header `#include "FIPS202.a.headers/SimpleFIPS202.h"`
+6. Use the functions in your code! In the following example, we will use `SHA3_256`:
+    ```c
+    // your input message
+    const unsigned char *input = 
+            (const unsigned char *) "The random message to hash";
+
+    // the output that will contain the hash
+    unsigned char output[32];
+
+    int result = SHA3_256(output, input, (const char *) input));
+
+    // returning 0 means success
+    assert(result == 0);
+
+    // printing the hash in hexadecimal format
+    for (int i = 0; i < 32; i++) {
+        printf("%02x", output[i]);
+    }
+    ```
+7. Before executing the code, you have to compile the code with the static library `FIPS202.a`. 
+When using `gcc`, this step might look like this:
+    ```bash
+    gcc main.c FIPS202_reference.a;
+    ```
+8. Run the executable:
+    ```bash
+    ./a.out
+    ```
+
+### Extendable output functions (XOFs)
+- `SHAKE128`
+- `SHAKE256`
+
+[//]: # (TODO: add example for XOFs)

--- a/usage-example.md
+++ b/usage-example.md
@@ -1564,7 +1564,6 @@ void authenticatedEncryptionWithRatchet() {
     unsigned char expectedTag[tagByteLen];
     Xoodyak_Squeeze(&decInstance, expectedTag, tagByteLen);
 
-    assert(memcmp(messages[0].data, decrypted, messageByteLen) == 0);
     assert(memcmp(tag, expectedTag, tagByteLen) == 0);
 }
 
@@ -1583,6 +1582,7 @@ An example of such usage is given below. Note that we're not focusing on the det
     <summary>Asymetric encryption example with Deffie-Hellman</summary>
 
 ```c
+
 void xoodyakCombinedMode() {
     // Alice and Bob have their own public keys
     unsigned char alicePublicKey[32] = "alice's public key";
@@ -1643,4 +1643,7 @@ void xoodyakCombinedMode() {
     // ...
 }
 
-````
+```
+
+</details>
+

--- a/usage-example.md
+++ b/usage-example.md
@@ -74,6 +74,8 @@ The following steps illustrate how to do that:
     get the output at once or in chunks as well (We'll show an example of that later, with the SHAKE128 XOF).
     
    ```c
+    #include "KeccakHash.h"
+
     int main() {
         const int CHUNKS_COUNT = 4;
 
@@ -149,6 +151,8 @@ The following steps illustrate how to do that:
     Since a XOF function has an arbitrary output length, you might want to read the output in chunks.
     
    ```c
+    #include "KeccakHash.h"
+
     int main() {
         // your input message
         const unsigned char *input = (const unsigned char *) "The random message to hash";
@@ -199,7 +203,7 @@ The following steps illustrate how to do that:
 
 </details>
 
-For more information on how to use the FIPS 202 functions, see the `SimpleFIPS202.h` header file.
+For more information on how to use the FIPS 202 functions, see the `SimpleFIPS202.h` and `KeccakHash.h` headers.
 
 ## TurboSHAKE
 `TurboSHAKE` is a family of fast and secure XOFs. These are just like the SHAKE functions of FIPS 202, but with the 

--- a/usage-example.md
+++ b/usage-example.md
@@ -1,4 +1,4 @@
-In this guide, we will provide examples of using the high-level API, with less emphasis on 
+In this guide, we will provide examples of using the high-level API, with less emphasis on
 the low-level implementation, since XKCP abstracts the low-level implementation from the user.
 
 Before proceeding with the usage example, please make sure that you have built the XKCP library as described in the [README](../README.md).
@@ -7,14 +7,17 @@ and included it in your C/C++ project.
 # Hashing and Extendable output functions (XOFs)
 
 ## FIPS 202
+
 Those are the NIST approved SHA-3 functions. They are based on the `Sponge construction`, and the `Keccak-p[1600, 24]` permutation.
 The functions are:
 
 ### Hash functions
-A hash function is a function on binary data (i.e., bit strings) for which the length of the output is fixed. <br> 
-The input to a hash function is called the _message_, and the output is called the _digest_ or _hash value_. 
+
+A hash function is a function on binary data (i.e., bit strings) for which the length of the output is fixed. <br>
+The input to a hash function is called the _message_, and the output is called the _digest_ or _hash value_.
 
 NIST standardized the following hash functions in FIPS 202:
+
 - `SHA3_224`
 - `SHA3_256`
 - `SHA3_384`
@@ -23,9 +26,11 @@ NIST standardized the following hash functions in FIPS 202:
 The suffix `224`, `256`, `384`, and `512` indicate the fixed length of the `digest` in bits.
 
 ### Extendable output functions (XOFs)
+
 A XOF is a function on bit strings, also called _messages_, in which the output can be extended to any desired length. <br>
 
 NIST standardized the following XOFs in FIPS 202, marking them as the first XOFs to be standardized by NIST.
+
 - `SHAKE128`
 - `SHAKE256`
 
@@ -37,34 +42,35 @@ To use any of them in your C/C++ project, you have to first build the FIPS202 li
 The following steps illustrate how to do that:
 
 #### Example of using the `SHA3_256` hash function
-    
+
 <details open>
     <summary>Simple usage</summary>
 
-   ```c
-   #include "SimpleFIPS202.h"
+```c
+#include "SimpleFIPS202.h"
 
-   int main() {
-      // your input message
-      const unsigned char *input = 
-              (const unsigned char *) "The random message to hash";
+int main() {
+   // your input message
+   const unsigned char *input =
+           (const unsigned char *) "The random message to hash";
 
-      int outputByteLen = 32;
-      unsigned char output[outputByteLen];
-      
-      int result = SHA3_256(output, input, strlen((const char *) input));
-      
-      // returning 0 means success
-      assert(result == 0);
-      
-      // printing the hash in hexadecimal format
-      for (int i = 0; i < outputByteLen; i++)
-          printf("\\x%02x", output[i]);
-      printf("\n");
+   int outputByteLen = 32;
+   unsigned char output[outputByteLen];
 
-      // ...
-   }
-   ```
+   int result = SHA3_256(output, input, strlen((const char *) input));
+
+   // returning 0 means success
+   assert(result == 0);
+
+   // printing the hash in hexadecimal format
+   for (int i = 0; i < outputByteLen; i++)
+       printf("\\x%02x", output[i]);
+   printf("\n");
+
+   // ...
+}
+```
+
 </details>
 
 <details open>
@@ -109,41 +115,43 @@ The following steps illustrate how to do that:
         // printing the hash in hexadecimal format
         for (int i = 0; i < outputByteLen; i++)
             printf("\\x%02x", output[i]);
-        printf("\n"); 
-        
+        printf("\n");
+
         // ...
     }
-   ```
+
+````
 </details>
 
 #### Example of using the `SHAKE128` XOF
 
 <details open>
-   <summary>Simple usage</summary>
+<summary>Simple usage</summary>
 
-   ```c
-    #include "SimpleFIPS202.h"
+```c
+ #include "SimpleFIPS202.h"
 
-    int main() {
-        // your input message
-        const unsigned char *input = (const unsigned char *) "The random message to hash";
+ int main() {
+     // your input message
+     const unsigned char *input = (const unsigned char *) "The random message to hash";
 
-        // you can choose any output length
-        int outputByteLen = 64;
-        unsigned char output[outputByteLen];
+     // you can choose any output length
+     int outputByteLen = 64;
+     unsigned char output[outputByteLen];
 
-        int result = SHAKE128(output, outputByteLen, input, strlen((const char *) input));
-        // returning 0 means success
-        assert(result == 0);
+     int result = SHAKE128(output, outputByteLen, input, strlen((const char *) input));
+     // returning 0 means success
+     assert(result == 0);
 
-        // printing the hash in hexadecimal format
-        for (int i = 0; i < outputByteLen; i++)
-           printf("\\x%02x", output[i]);
-        printf("\n");
+     // printing the hash in hexadecimal format
+     for (int i = 0; i < outputByteLen; i++)
+        printf("\\x%02x", output[i]);
+     printf("\n");
 
-        // ...
-    }
-   ```
+     // ...
+ }
+````
+
 </details>
 
 <details open>
@@ -199,15 +207,16 @@ The following steps illustrate how to do that:
 
         // ...
     }
-   ```
+
+````
 
 </details>
 
 For more information on how to use the FIPS 202 functions, see the `SimpleFIPS202.h` and `KeccakHash.h` headers.
 
 ## TurboSHAKE
-`TurboSHAKE` is a family of fast and secure XOFs. These are just like the SHAKE functions of FIPS 202, but with the 
-Keccak-p permutation reduced to 12 rounds (instead of 24), so about twice faster. 
+`TurboSHAKE` is a family of fast and secure XOFs. These are just like the SHAKE functions of FIPS 202, but with the
+Keccak-p permutation reduced to 12 rounds (instead of 24), so about twice faster.
 They are based on the `Sponge construction`, and the `Keccak-p[1600, 12]` permutation.
 
 There are 2 main functions in this family:
@@ -219,33 +228,34 @@ The suffix `128` and `256` indicates the desired security level of the function.
 We will give usage examples of the `TurboSHAKE128` function, but the same applies to the `TurboSHAKE256` function.
 
 <details open>
-   <summary>Simple usage</summary>
+<summary>Simple usage</summary>
 
-   ```c
-    #include "TurboSHAKE.h"
+```c
+ #include "TurboSHAKE.h"
 
-    int main() {
-        // your input message
-        const unsigned char *input = (const unsigned char *) "The random message to hash";
+ int main() {
+     // your input message
+     const unsigned char *input = (const unsigned char *) "The random message to hash";
 
-        // you can choose any output length
-        int outputByteLen = 512;
-        unsigned char output[outputByteLen];
+     // you can choose any output length
+     int outputByteLen = 512;
+     unsigned char output[outputByteLen];
 
-        // choose a domain separation in the range `[0x01, 0x02, .. , 0x7F]`
-        unsigned char domain = 0x1F;
+     // choose a domain separation in the range `[0x01, 0x02, .. , 0x7F]`
+     unsigned char domain = 0x1F;
 
-        int result = TurboSHAKE(256, input, strlen((const char *) input), domain, output, outputByteLen);
-        assert(result == 0);  // returning 0 means success
+     int result = TurboSHAKE(256, input, strlen((const char *) input), domain, output, outputByteLen);
+     assert(result == 0);  // returning 0 means success
 
-        // printing the hash in hexadecimal format
-        for (int i = 0; i < outputByteLen; i++)
-           printf("\\x%02x", output[i]);
-        printf("\n");
+     // printing the hash in hexadecimal format
+     for (int i = 0; i < outputByteLen; i++)
+        printf("\\x%02x", output[i]);
+     printf("\n");
 
-        // ...
-    }
-   ```
+     // ...
+ }
+````
+
 </details>
 
 <details open>
@@ -260,7 +270,7 @@ We will give usage examples of the `TurboSHAKE128` function, but the same applie
         const unsigned char *input = (const unsigned char *) "The random message to hash";
 
         TurboSHAKE_Instance tsi;
-        
+
         // initialize the turboSHAKE instance
         int result = TurboSHAKE_Initialize(&tsi, 256);
         assert(result == 0);
@@ -301,7 +311,8 @@ We will give usage examples of the `TurboSHAKE128` function, but the same applie
 
         // ...
     }
-   ```
+
+````
 </details>
 
 ## KangarooTwelve
@@ -311,28 +322,29 @@ On high-end platforms, it can exploit a high degree of parallelism, whether usin
 We will give 2 examples of using the `KangarooTwelve` function, one for the simple usage, with single input single output, then a more advanced example, with chunked input/output.
 
 <details open>
-   <summary>Simple usage</summary>
+<summary>Simple usage</summary>
 
-   ```c
-    #include "KangarooTwelve.h"
+```c
+ #include "KangarooTwelve.h"
 
-    int main() {
-        const unsigned char *input = (const unsigned char *) "The random message to hash";
+ int main() {
+     const unsigned char *input = (const unsigned char *) "The random message to hash";
 
-        const int outputByteLen = 64;
-        unsigned char output[outputByteLen];
+     const int outputByteLen = 64;
+     unsigned char output[outputByteLen];
 
-        int result = KangarooTwelve(input, strlen((const char *) input), output, outputByteLen, NULL, 0);
-        assert(result == 0);  // returning 0 means success
+     int result = KangarooTwelve(input, strlen((const char *) input), output, outputByteLen, NULL, 0);
+     assert(result == 0);  // returning 0 means success
 
-        // printing the hash in hexadecimal format
-        for (int i = 0; i < outputByteLen; i++)
-           printf("\\x%02x", output[i]);
-        printf("\n");
+     // printing the hash in hexadecimal format
+     for (int i = 0; i < outputByteLen; i++)
+        printf("\\x%02x", output[i]);
+     printf("\n");
 
-        // ...
-    }
-   ```
+     // ...
+ }
+````
+
 </details>
 
 <details open>
@@ -387,12 +399,13 @@ We will give 2 examples of using the `KangarooTwelve` function, one for the simp
 
         // ...
     }
-   ```
+
+````
 </details>
 
 # General-purpose deck functions
 
-A deck function allows us to feed arbitrary long input chunks and get arbitrary long output chunks interchangeably, 
+A deck function allows us to feed arbitrary long input chunks and get arbitrary long output chunks interchangeably,
 while offering incremental properties on the input and output, helping in speeding up the computation.
 
 ## Kravatte
@@ -402,152 +415,499 @@ while offering incremental properties on the input and output, helping in speedi
 ### Basic usages
 
 <details open>
-   <summary>Single input single output</summary>
+<summary>Single input single output</summary>
 
-   ```c
-    #include "Kravatte.h"
+```c
+ #include "Kravatte.h"
 
-    int main() {
-        // choose your key
-        const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
-        
-        const unsigned char *input = (const unsigned char *) "a random input message";
+ int main() {
+     // choose your key
+     const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
 
-        Kravatte_Instance ki;
-        int result;
+     const unsigned char *input = (const unsigned char *) "a random input message";
 
-        // initialize the Kravatte instance
-        result = Kravatte_MaskDerivation(&ki, key, strlen((const char *) key) * 8);
-        assert(result == 0);
+     Kravatte_Instance ki;
+     int result;
 
-        int outputByteLen = 32;
-        unsigned char output[outputByteLen];
+     // initialize the Kravatte instance
+     result = Kravatte_MaskDerivation(&ki, key, strlen((const char *) key) * 8);
+     assert(result == 0);
 
-        // one call to feed the input and get the output
-        result = Kravatte(&ki, input, strlen((const char *) input) * 8, output, outputByteLen * 8, 0);
-        assert(result == 0);
+     int outputByteLen = 32;
+     unsigned char output[outputByteLen];
 
-        // printing the hash in hexadecimal format
-        for (int i = 0; i < outputByteLen; i++)
-           printf("\\x%02x", output[i]);
-        printf("\n");
+     // one call to feed the input and get the output
+     result = Kravatte(&ki, input, strlen((const char *) input) * 8, output, outputByteLen * 8, 0);
+     assert(result == 0);
 
-        // ...
-    }
-   ```
+     // printing the hash in hexadecimal format
+     for (int i = 0; i < outputByteLen; i++)
+        printf("\\x%02x", output[i]);
+     printf("\n");
+
+     // ...
+ }
+````
+
 </details>
 
 <details open>
     <summary>Advanced: Multiple input single output</summary>
     We will feed the input in chunks, and get the output at once.
 
-   ```c
-    #include "Kravatte.h"
+```c
+ #include "Kravatte.h"
 
-    int main() {
-        const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
+ int main() {
+     const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
 
-        const int inputChunksCount = 4;
-        const unsigned char *input[inputChunksCount] = {
-            (const unsigned char *) "a ",
-            (const unsigned char *) "random ",
-            (const unsigned char *) "input ",
-            (const unsigned char *) "message"
-        };
+     const int inputChunksCount = 4;
+     const unsigned char *input[inputChunksCount] = {
+         (const unsigned char *) "a ",
+         (const unsigned char *) "random ",
+         (const unsigned char *) "input ",
+         (const unsigned char *) "message"
+     };
 
-        const unsigned char *expectedOutput = (const unsigned char *)
-                "\xf9\x98\x1b\x67\x97\xbf\xf5\x45\xf5\xd1\xae\x6d\x33\x14\xb0\x99"
-                "\xcd\x9c\x5a\xcb\x52\xa4\x56\x69\xf7\xea\x52\xc8\x30\xf6\xb3\x7e";
+     const unsigned char *expectedOutput = (const unsigned char *)
+             "\xf9\x98\x1b\x67\x97\xbf\xf5\x45\xf5\xd1\xae\x6d\x33\x14\xb0\x99"
+             "\xcd\x9c\x5a\xcb\x52\xa4\x56\x69\xf7\xea\x52\xc8\x30\xf6\xb3\x7e";
 
-        Kravatte_Instance ki;
-        int result;
+     Kravatte_Instance ki;
+     int result;
 
-        result = Kravatte_MaskDerivation(&ki, key,
-        strlen((const char *) key) * 8);
-        assert(result == 0);
+     result = Kravatte_MaskDerivation(&ki, key,
+     strlen((const char *) key) * 8);
+     assert(result == 0);
 
-        // feeding the input in chunks
-        for (int i = 0; i < inputChunksCount; i++) {
-            int flags = (i == inputChunksCount - 1) ? KRAVATTE_FLAG_LAST_PART : 0;
-            result = Kra(&ki, input[i], strlen((const char *) input[i]) * 8, flags);
-            assert(result == 0);
-        }
+     // feeding the input in chunks
+     for (int i = 0; i < inputChunksCount; i++) {
+         int flags = (i == inputChunksCount - 1) ? KRAVATTE_FLAG_LAST_PART : 0;
+         result = Kra(&ki, input[i], strlen((const char *) input[i]) * 8, flags);
+         assert(result == 0);
+     }
 
-        int outputByteLen = 32;
-        unsigned char output[outputByteLen];
+     int outputByteLen = 32;
+     unsigned char output[outputByteLen];
 
-        // getting the output at once
-        result = Vatte(&ki, output, outputByteLen * 8, KRAVATTE_FLAG_LAST_PART);
-        assert(result == 0);
+     // getting the output at once
+     result = Vatte(&ki, output, outputByteLen * 8, KRAVATTE_FLAG_LAST_PART);
+     assert(result == 0);
 
-        // printing the output chunk in hexadecimal format
-        for (int i = 0; i < outputByteLen; i++)
-            printf("\\x%02x", output[i]);
-        printf("\n");
+     // printing the output chunk in hexadecimal format
+     for (int i = 0; i < outputByteLen; i++)
+         printf("\\x%02x", output[i]);
+     printf("\n");
 
-        // ...
-    }
+     // ...
+ }
 
-   ```
+```
+
 </details>
 
 <details open>
     <summary>Advanced: Single input multiple output</summary>
     We will feed the input at once, and get the output in chunks.
 
-   ```c
-    #include "Kravatte.h"
+```c
+ #include "Kravatte.h"
 
-    int main() {
-        const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
-        const unsigned char *input = (const unsigned char *) "a random input message";
+ int main() {
+     const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
+     const unsigned char *input = (const unsigned char *) "a random input message";
 
-        Kravatte_Instance ki;
-        int result;
+     Kravatte_Instance ki;
+     int result;
 
-        result = Kravatte_MaskDerivation(&ki, key,
-        strlen((const char *) key) * 8);
-        assert(result == 0);
+     result = Kravatte_MaskDerivation(&ki, key,
+     strlen((const char *) key) * 8);
+     assert(result == 0);
 
-        // feeding the input at once
-        result = Kra(&ki, input, strlen((const char *) input) * 8, KRAVATTE_FLAG_LAST_PART);
-        assert(result == 0);
+     // feeding the input at once
+     result = Kra(&ki, input, strlen((const char *) input) * 8, KRAVATTE_FLAG_LAST_PART);
+     assert(result == 0);
 
 
-        const int outputChunksCount = 2;
-        const int outputChunkByteLen = 16;
-        unsigned char chunkOutput[outputChunkByteLen];
+     const int outputChunksCount = 2;
+     const int outputChunkByteLen = 16;
+     unsigned char chunkOutput[outputChunkByteLen];
 
-        // initialize the full output
-        const int fullOutputByteLen = outputChunkByteLen * outputChunksCount;
-        unsigned char output[fullOutputByteLen]; 
+     // initialize the full output
+     const int fullOutputByteLen = outputChunkByteLen * outputChunksCount;
+     unsigned char output[fullOutputByteLen];
 
-        // getting the output in chunks
-        for (int i = 0; i < outputChunksCount; i++) {
-            int flags = (i == outputChunksCount - 1) ? KRAVATTE_FLAG_LAST_PART : 0;
-            result = Vatte(&ki, chunkOutput, outputChunkByteLen * 8, flags);
-            assert(result == 0);
-            // incrementally build the output, like writing to a file.
-            // for simplicity, we use `memcpy` in this example:
-            memcpy(output + (i * outputChunkByteLen), chunkOutput, outputChunkByteLen);
-        }
+     // getting the output in chunks
+     for (int i = 0; i < outputChunksCount; i++) {
+         int flags = (i == outputChunksCount - 1) ? KRAVATTE_FLAG_LAST_PART : 0;
+         result = Vatte(&ki, chunkOutput, outputChunkByteLen * 8, flags);
+         assert(result == 0);
+         // incrementally build the output, like writing to a file.
+         // for simplicity, we use `memcpy` in this example:
+         memcpy(output + (i * outputChunkByteLen), chunkOutput, outputChunkByteLen);
+     }
 
-        // printing the output chunk in hexadecimal format
-        for (int i = 0; i < fullOutputByteLen; i++)
-            printf("\\x%02x", output[i]);
-        printf("\n");
+     // printing the output chunk in hexadecimal format
+     for (int i = 0; i < fullOutputByteLen; i++)
+         printf("\\x%02x", output[i]);
+     printf("\n");
 
-        // ...
-    }
-   ```
+     // ...
+ }
+```
+
 </details>
     
 Those examples can be adapted to support multiple input multiple output as well, by using a sequence of `Kra` and `Vatte` calls.
 
-### {{ More interesting examples based on the Kravatte modes SANE, SANSE, and WBC }} 
+### SANE mode (Authenticated Encryption)
 
+SANE is an authenticated encryption scheme supporting sessions, the tag for the message n authenticates
+the full history of the session up to that point, i.e. the messages 1, 2, ..., n. <br>
+
+<details open>
+   <summary>Authenticated Encryption: conversation example</summary>
+
+```c
+#include "KravatteModes.h"
+
+struct Message
+{
+    unsigned char *data;
+    unsigned char *metadata;
+} Message;
+
+struct Message messages[] = {
+    {(unsigned char *)"Hello, how is it going?", (unsigned char *)"time: 2020-12-12 12:12:12"},
+    {(unsigned char *)"Can we meet at 12:30?", (unsigned char *)"time: 2020-12-12 12:12:13"},
+    {(unsigned char *)"I want to talk about the project", (unsigned char *)"time: 2020-12-12 12:12:14"}};
+
+
+int main() {
+    // ksiEnc is the sender, while ksiDec is the receiver
+    Kravatte_SANE_Instance ksiEnc;
+    Kravatte_SANE_Instance ksiDec;
+
+    // choose any key
+    const int keyBitLen = 256;
+    BitSequence key[keyBitLen] = "alksjdfo2300a9sdflkjasdfdq343ag2";
+
+    // choose the nonce. it must be the same for both ksiEnc and ksiDec
+    const int nonceBitLen = 128;
+    BitSequence nonce[nonceBitLen] = "alksjdfo2300a9sd";
+
+    BitSequence tagEnc[Kravatte_SANE_TagLength];
+    BitSequence tagDec[Kravatte_SANE_TagLength];
+
+    int result;
+
+    // initialize the instance for both sender and receiver
+    // make sure to use the same key/nonce pair for both,
+    // otherwise, `tagEnc` and `tagDec` won't match.
+
+    result = Kravatte_SANE_Initialize(&ksiEnc, key, keyBitLen, nonce, nonceBitLen, tagEnc);
+    assert(result == 0);
+
+    result = Kravatte_SANE_Initialize(&ksiDec, key, keyBitLen, nonce, nonceBitLen, tagDec);
+    assert(result == 0);
+
+    assert(memcmp(tagEnc, tagDec, Kravatte_SANE_TagLength) == 0);
+
+    BitSequence *ciphertexts[3];
+    BitSequence *tags[3];
+
+    // Encrypt the messages by the sender
+    for (int i = 0; i < 3; i++)
+    {
+        struct Message message = messages[i];
+
+        int messageBitLen = strlen((const char *)message.data) * 8;
+        ciphertexts[i] = malloc(sizeof(BitSequence) * (messageBitLen / 8));
+
+        tags[i] = malloc(sizeof(BitSequence) * Kravatte_SANE_TagLength);
+
+        int metadataBitLen = strlen((const char *)message.metadata) * 8;
+
+        // encrypt the message and store the ciphertext and the tag in `ciphertexts[i]`
+        // and `tag[i]` for later use by the decryptor. In real application, we will
+        // be sending ciphertext and the tag over the wire towards the decryptor.
+
+        result = Kravatte_SANE_Wrap(
+            &ksiEnc,
+            message.data, ciphertexts[i], messageBitLen,
+            message.metadata, metadataBitLen,
+            tags[i]);
+
+        assert(result == 0);
+    }
+
+    // CAUTION: uncomment the line below (tempering with the ciphertexts)
+    // for the decryption to fail (i.e. for Kravatte_SANE_Unwrap to return 1)
+    // ciphertexts[0][0] ^= 1;
+
+    // Decrypt the messages by the receiver
+    for (int i = 0; i < 3; i++)
+    {
+        struct Message message = messages[i];
+
+        int messageBitLen = strlen((const char *)message.data) * 8;
+        BitSequence *plaintext = malloc(sizeof(BitSequence) * (messageBitLen / 8));
+
+        int metadataBitLen = strlen((const char *)message.metadata) * 8;
+
+        result = Kravatte_SANE_Unwrap(
+            &ksiDec,
+            ciphertexts[i], plaintext, messageBitLen,
+            message.metadata, metadataBitLen,
+            tags[i]);
+
+        assert(result == 0); // no corruption detected, tag is valid
+
+        assert(memcmp(plaintext, message.data, messageBitLen / 8) == 0);
+    }
+
+    // don't forget to free the memory :)
+    for (int i = 0; i < 3; i++)
+    {
+        free(ciphertexts[i]);
+        free(tags[i]);
+    }
+    // ...
+}
+```
+
+</details>
+
+### SANSE mode (Authenticated Encryption)
+
+Like SANE, SANE is an authenticated encryption scheme supporting sessions, the tag for the message n authenticates
+the full history of the session up to that point, i.e. the messages 1, 2, ..., n. <br>
+
+However, SANSE is a nonce-misuse resistant version of SANE, and doesn't require the user to provide a nonce.
+Instead, it uses a nonce internally, and the user only needs to provide a key.
+
+For better security, a user can include a nonce in the metadata of the first message.
+
+<!-- TODO: clarify more about nonce misuse resistant of SANSE? -->
+
+<details open>
+   <summary>Authenticated Encryption: conversation example</summary>
+
+```c
+#include "KravatteModes.h"
+
+struct Message
+{
+    unsigned char *data;
+    unsigned char *metadata;
+} Message;
+
+struct Message messages[] = {
+    {(unsigned char *)"Hello, how is it going?", (unsigned char *)"time: 2020-12-12 12:12:12"},
+    {(unsigned char *)"Can we meet at 12:30?", (unsigned char *)"time: 2020-12-12 12:12:13"},
+    {(unsigned char *)"I want to talk about the project", (unsigned char *)"time: 2020-12-12 12:12:14"}};
+
+
+int main() {
+    // ksiEnc is the sender, while ksiDec is the receiver
+    Kravatte_SANSE_Instance ksiEnc;
+    Kravatte_SANSE_Instance ksiDec;
+
+    // choose any key
+    const int keyBitLen = 256;
+    BitSequence key[keyBitLen] = "alksjdfo2300a9sdflkjasdfdq343ag2";
+
+    BitSequence tagEnc[Kravatte_SANE_TagLength];
+    BitSequence tagDec[Kravatte_SANE_TagLength];
+
+    int result;
+
+    // initialize the instance for both sender and receiver with the same key
+
+    result = Kravatte_SANSE_Initialize(&ksiEnc, key, keyBitLen);
+    assert(result == 0);
+
+    result = Kravatte_SANSE_Initialize(&ksiDec, key, keyBitLen);
+    assert(result == 0);
+
+    BitSequence *ciphertexts[3];
+    BitSequence *tags[3];
+
+    // Encrypt the messages by the sender
+    for (int i = 0; i < 3; i++)
+    {
+        struct Message message = messages[i];
+
+        int messageBitLen = strlen((const char *)message.data) * 8;
+        ciphertexts[i] = malloc(sizeof(BitSequence) * (messageBitLen / 8));
+
+        tags[i] = malloc(sizeof(BitSequence) * Kravatte_SANSE_TagLength);
+
+        int metadataBitLen = strlen((const char *)message.metadata) * 8;
+
+        // encrypt the message and store the ciphertext and the tag in `ciphertexts[i]`
+        // and `tag[i]` for later use by the decryptor. In real application, we will
+        // be sending ciphertext and the tag over the wire towards the decryptor.
+
+        result = Kravatte_SANSE_Wrap(
+            &ksiEnc,
+            message.data, ciphertexts[i], messageBitLen,
+            message.metadata, metadataBitLen,
+            tags[i]);
+
+        assert(result == 0);
+    }
+
+    // CAUTION: uncomment the line below (tempering with the ciphertexts)
+    // for the decryption to fail (i.e. for Kravatte_SANSE_Unwrap to return 1)
+    // ciphertexts[0][0] ^= 1;
+
+    // Decrypt the messages by the receiver
+    for (int i = 0; i < 3; i++)
+    {
+        struct Message message = messages[i];
+
+        int messageBitLen = strlen((const char *)message.data) * 8;
+        BitSequence *plaintext = malloc(sizeof(BitSequence) * (messageBitLen / 8));
+
+        int metadataBitLen = strlen((const char *)message.metadata) * 8;
+
+        result = Kravatte_SANSE_Unwrap(
+            &ksiDec,
+            ciphertexts[i], plaintext, messageBitLen,
+            message.metadata, metadataBitLen,
+            tags[i]);
+
+        assert(result == 0); // no corruption detected, tag is valid
+
+        assert(memcmp(plaintext, message.data, messageBitLen / 8) == 0);
+    }
+
+    // don't forget to free the memory :)
+    for (int i = 0; i < 3; i++)
+    {
+        free(ciphertexts[i]);
+        free(tags[i]);
+    }
+
+    // ...
+}
+```
+
+</details>
+
+### WBC mode (Wide Block Cipher)
+
+WBC is a wide block cipher mode, Built on top of the Farfalle construction and the Feistel network.
+It can be used to encrypt a message of any length, and produce a ciphertext of the same length.
+
+<details open>
+   <summary>Simple encryption/decryption example</summary>
+
+```c
+#include "KravatteModes.h"
+
+int main() {
+    Kravatte_Instance kwiEnc;
+
+    // choose any key
+    const int keyBitLen = 256;
+    BitSequence key[keyBitLen] = "alksjdfo2300a9sdflkjasdfdq343ag2";
+
+    int result;
+
+    // initialize the WBC instance
+    result = Kravatte_WBC_Initialize(&kwiEnc, key, keyBitLen);
+    assert(result == 0);
+
+    const BitSequence *plaintext = (const BitSequence *)"The random message to encrypt";
+    int messageBitLen = strlen((const char *)plaintext) * 8;
+
+    BitSequence *ciphertext = malloc(sizeof(BitSequence) * (messageBitLen / 8));
+
+    // choose a unique tweak - it must be the same for the encryption and decryption
+    const int tweakBitLen = 128;
+    BitSequence tweak[tweakBitLen] = "alksjdfo2300a9sd";
+
+    result = Kravatte_WBC_Encipher(&kwiEnc, plaintext, ciphertext, messageBitLen, tweak, tweakBitLen);
+    assert(result == 0);
+
+    BitSequence *decrypted = malloc(sizeof(BitSequence) * (messageBitLen / 8));
+
+    // if the tweak is not the same as the one used for encryption, the decryption will fail
+    result = Kravatte_WBC_Decipher(&kwiEnc, ciphertext, decrypted, messageBitLen, tweak, tweakBitLen);
+    assert(result == 0);
+
+    assert(memcmp(plaintext, decrypted, messageBitLen / 8) == 0);
+
+    // ...
+}
+```
+
+</details>
+
+### WBC-AE mode (Wide Block Cipher Authenticated Encryption)
+
+WBC-AE is an Authenticated Encryption mode, Built on top of the WBC mode.
+
+<details open>
+   <summary>Simple encryption/decryption example with authentication</summary>
+
+```c
+#include "KravatteModes.h"
+
+int main() {
+    Kravatte_Instance kwiInstance;
+
+    // choose any key
+    const int keyBitLen = 256;
+    BitSequence key[keyBitLen] = "alksjdfo2300a9sdflkjasdfdq343ag2";
+
+    int result;
+
+    // initialize the WBC-AE instance
+    result = Kravatte_WBCAE_Initialize(&kwiInstance, key, keyBitLen);
+    assert(result == 0);
+
+    char plaintext[] = "The random message to encrypt";
+    int messageBitLen = strlen((const char *)plaintext) * 8;
+
+    // WBC_AE adds additional `Kravatte_WBCAE_t` bits to the message as tag
+    // so we need to allocate buffers with size `messageBitLen + Kravatte_WBCAE_t`
+    int extendedBitLen = messageBitLen + Kravatte_WBCAE_t;
+
+    BitSequence *plaintext = malloc((extendedBitLen) / 8);
+    memcpy(plaintext, plaintext, messageBitLen / 8);
+
+    BitSequence *ciphertext = malloc((extendedBitLen) / 8);
+
+    const int metadataBitLen = 200;
+    BitSequence metadata[metadataBitLen] = "time: 2020-12-12 12:12:12";
+
+    // encrypt the message
+    result = Kravatte_WBCAE_Encipher(&kwiInstance, plaintext, ciphertext, messageBitLen, metadata, metadataBitLen);
+    assert(result == 0);
+
+    // CAUTION: uncomment the line below (tempering with the ciphertexts)
+    // for the decryption to fail (i.e. for Kravatte_WBCAE_Decipher to return 1)
+    // ciphertext_extended[0] ^= 1;
+
+    unsigned char *decrypted = malloc((extendedBitLen) / 8);
+
+    result = Kravatte_WBCAE_Decipher(&kwiInstance, ciphertext, decrypted, messageBitLen, metadata, metadataBitLen);
+    assert(result == 0);
+
+    assert(memcmp(plaintext, decrypted, messageBitLen / 8) == 0);
+
+    // don't forget to free the memory :)
+    free(ciphertext);
+    free(decrypted);
+
+    // ...
+}
 ...
 
 ## Xoofff
 
 ## Xoodyak
+```

--- a/usage-example.md
+++ b/usage-example.md
@@ -717,8 +717,8 @@ int main() {
     const int keyBitLen = 256;
     BitSequence key[keyBitLen] = "alksjdfo2300a9sdflkjasdfdq343ag2";
 
-    BitSequence tagEnc[Kravatte_SANE_TagLength];
-    BitSequence tagDec[Kravatte_SANE_TagLength];
+    BitSequence tagEnc[Kravatte_SANSE_TagLength];
+    BitSequence tagDec[Kravatte_SANSE_TagLength];
 
     int result;
 
@@ -876,8 +876,8 @@ int main() {
     // so we need to allocate buffers with size `messageBitLen + Kravatte_WBCAE_t`
     int extendedBitLen = messageBitLen + Kravatte_WBCAE_t;
 
-    BitSequence *plaintext = malloc((extendedBitLen) / 8);
-    memcpy(plaintext, plaintext, messageBitLen / 8);
+    BitSequence *plaintext_buffer = malloc((extendedBitLen) / 8);
+    memcpy(plaintext_buffer, plaintext, messageBitLen / 8);
 
     BitSequence *ciphertext = malloc((extendedBitLen) / 8);
 
@@ -885,7 +885,7 @@ int main() {
     BitSequence metadata[metadataBitLen] = "time: 2020-12-12 12:12:12";
 
     // encrypt the message
-    result = Kravatte_WBCAE_Encipher(&kwiInstance, plaintext, ciphertext, messageBitLen, metadata, metadataBitLen);
+    result = Kravatte_WBCAE_Encipher(&kwiInstance, plaintext_buffer, ciphertext, messageBitLen, metadata, metadataBitLen);
     assert(result == 0);
 
     // CAUTION: uncomment the line below (tempering with the ciphertexts)

--- a/usage-example.md
+++ b/usage-example.md
@@ -80,48 +80,49 @@ int main() {
     get the output at once or in chunks as well.
     (We'll show an example of that later, with the SHAKE128 XOF.)
 
-   ```c
-    #include "KeccakHash.h"
+```c
+ #include "KeccakHash.h"
 
-    int main() {
-        const int inputChunksCount = 4;
+ int main() {
+     const int inputChunksCount = 4;
 
-        const unsigned char *input[inputChunksCount] = {
-            (const unsigned char *) "Hello, ",
-            (const unsigned char *) "this is ",
-            (const unsigned char *) "my custom ",
-            (const unsigned char *) "message!"
-        };
+     const unsigned char *input[inputChunksCount] = {
+         (const unsigned char *) "Hello, ",
+         (const unsigned char *) "this is ",
+         (const unsigned char *) "my custom ",
+         (const unsigned char *) "message!"
+     };
 
-        Keccak_HashInstance hi;
-        HashReturn result;
+     Keccak_HashInstance hi;
+     HashReturn result;
 
-        // initialize the hash instance
-        result = Keccak_HashInitialize_SHA3_256(&hi);
-        assert(result == KECCAK_SUCCESS);
+     // initialize the hash instance
+     result = Keccak_HashInitialize_SHA3_256(&hi);
+     assert(result == KECCAK_SUCCESS);
 
-        for (int i = 0; i < inputChunksCount; i++) {
-            // feed the input in chunks
-            Keccak_HashUpdate(&hi, input[i], strlen((const char *) input[i]) * 8);
-            assert(result == KECCAK_SUCCESS);
-        }
+     for (int i = 0; i < inputChunksCount; i++) {
+         // feed the input in chunks
+         Keccak_HashUpdate(&hi, input[i], strlen((const char *) input[i]) * 8);
+         assert(result == KECCAK_SUCCESS);
+     }
 
-        int outputByteLen = 32;
-        unsigned char output[outputByteLen];
+     int outputByteLen = 32;
+     unsigned char output[outputByteLen];
 
-        // get the output
-        result = Keccak_HashFinal(&hi, output);
-        assert(result == KECCAK_SUCCESS);
+     // get the output
+     result = Keccak_HashFinal(&hi, output);
+     assert(result == KECCAK_SUCCESS);
 
-        // printing the hash in hexadecimal format
-        for (int i = 0; i < outputByteLen; i++)
-            printf("\\x%02x", output[i]);
-        printf("\n");
+     // printing the hash in hexadecimal format
+     for (int i = 0; i < outputByteLen; i++)
+         printf("\\x%02x", output[i]);
+     printf("\n");
 
-        // ...
-    }
+     // ...
+ }
 
-````
+```
+
 </details>
 
 #### Example of using the `SHAKE128` XOF
@@ -151,7 +152,7 @@ int main() {
 
      // ...
  }
-````
+```
 
 </details>
 
@@ -904,7 +905,7 @@ void multipleInputSingleOutput()
     // intialize the instance, with no key, no id, and no counter
     Xoodyak_Initialize(&instance, NULL, 0, NULL, 0, NULL, 0);
 
-    // absorb multiple messages, as chunks in multiple calls
+    // absorb multiple messages
     Xoodyak_Absorb(&instance, messages[0].data, strlen((char *)messages[0].data));
     Xoodyak_Absorb(&instance, messages[1].data, strlen((char *)messages[1].data));
     Xoodyak_Absorb(&instance, messages[2].data, strlen((char *)messages[2].data));
@@ -936,19 +937,19 @@ void singleInputMultipleOutput()
     const int outputByteLen = 16;
     unsigned char output[outputByteLen];
 
-    // get the hash in multiple calls
+    // squeeze multiple outputs
     for (int i = 0; i < 2; i++)
     {
         Xoodyak_Squeeze(&instance, output, outputByteLen);
 
-        // print the chunk in hexadecimal format
+        // print the output in hexadecimal format
         for (int i = 0; i < outputByteLen; i++)
             printf("\\x%02x", output[i]);
         printf("\n");
 
-        // NOTE: the first chunk should be the same as the first 16 bytes of the output of
+        // NOTE: the first output should be the same as the first 16 bytes of the output of
         // the `singleInputSingleOuput` example above - this is due to the Cyclist properties.
-        // However, the second chunk onwards will be different.
+        // However, the second output onwards will be different.
     }
 
     // ...
@@ -961,7 +962,7 @@ void multipleInputMultipleOutput()
     // intialize the instance, with no key, no id, and no counter
     Xoodyak_Initialize(&instance, NULL, 0, NULL, 0, NULL, 0);
 
-    // absorb multiple messages, as chunks in multiple calls
+    // absorb multiple messages
     Xoodyak_Absorb(&instance, messages[0].data, strlen((char *)messages[0].data));
     Xoodyak_Absorb(&instance, messages[1].data, strlen((char *)messages[1].data));
     Xoodyak_Absorb(&instance, messages[2].data, strlen((char *)messages[2].data));
@@ -969,20 +970,20 @@ void multipleInputMultipleOutput()
     const int outputByteLen = 16;
     unsigned char output[outputByteLen];
 
-    // get the hash in multiple calls
+    // squeeze multiple outputs
     for (int i = 0; i < 2; i++)
     {
 
         Xoodyak_Squeeze(&instance, output, outputByteLen);
 
-        // print the chunk in hexadecimal format
+        // print the output in hexadecimal format
         for (int i = 0; i < outputByteLen; i++)
             printf("\\x%02x", output[i]);
         printf("\n");
 
-        // NOTE: the first chunk should be the same as the first 16 bytes of the output of
+        // NOTE: the first output should be the same as the first 16 bytes of the output of
         // the `multipleInputSingleOutput` example above - this is due to the Cyclist properties.
-        // However, the second chunk onwards will be different.
+        // However, the second output onwards will be different.
     }
 
     // ...
@@ -1001,7 +1002,7 @@ Note that in the following examples, we will use the same `messages` array used 
 
 <details open>
     <summary>Simple encryption/decryption</summary>
-    
+
 ```c
 #include "Xoodyak.h"
 
@@ -1043,7 +1044,6 @@ Xoodyak_Instance decInstance;
 ````
 
 </details>
-
 
 <details open>
     <summary>Authenticated Encryption: simple example</summary>
@@ -1121,7 +1121,6 @@ void authenticatedEncryption() {
 ```
 
 </details>
-
 
 <details open>
     <summary>Authenticated Encryption: Session (aka conversation) example</summary>
@@ -1229,7 +1228,7 @@ void sessionAuthenticatedEncryption() {
     // the following line and the tags will not match -> Authentication insured.
     // confirmationEncrypted[0] ^= 1;
 
-    // Alice receives the confirmation message and ensure that it's authenticated:
+    // Alice receives the confirmation message and ensures that it's authenticated:
 
     unsigned char confirmationDecrypted[32];
     Xoodyak_Decrypt(&aliceInstance, confirmationEncrypted, confirmationDecrypted, 32);
@@ -1254,7 +1253,6 @@ void sessionAuthenticatedEncryption() {
 ```
 
 </details>
-
 
 <details open>
     <summary>Authenticated Encryption: Session with rolling subkeys example</summary>
@@ -1427,7 +1425,6 @@ void authenticatedEncryptionWithRatchet() {
 
 </details>
 
-
 ### Combining hash and keyed modes
 
 A key exchange protocol, such as Diffie-Hellman or variant, results in a common secret that usually requires further derivation before being used as a symmetric secret key. To do this with a Xoodyak, we can first use it in hash mode to process the common secret, and then use the derived key with Xoodyak in keyed mode.
@@ -1502,4 +1499,3 @@ void xoodyakCombinedMode() {
 ```
 
 </details>
-

--- a/usage-example.md
+++ b/usage-example.md
@@ -905,9 +905,76 @@ int main() {
 
     // ...
 }
+```
+
 ...
 
 ## Xoofff
 
+Xoofff is similar to Kravatte, it's also built on top of the Farfalle construction, however,
+it uses the Xoodoo permutation as primitive instead of the Keccak-p used in Kravatte, which makes it more suitable for constrained environments.
+
+Xoofff has an API similar to Kravatte, so the examples of Kravatte can be adapted to use Xoofff.
+In the following, we will give the differences between the APIs of Kravatte and Xoofff.
+
+One can use the below to adapt the examples of Kravatte to use Xoofff.
+
+### Basic usages
+
+| Feature                   | Kravatte                | Xoofff                |
+| ------------------------- | ----------------------- | --------------------- |
+| Header                    | "Kravatte.h"            | "Xoofff.h"            |
+| Instance Type             | Kravatte_Instance       | Xoofff_Instance       |
+| Initialization            | Kravatte_MaskDerivation | Xoofff_MaskDerivation |
+| One call Hashing Function | Kravatte                | Xoofff                |
+| Input feeding Function    | Kra                     | Xoofff_Compress       |
+| Output Retrieval Function | Vatte                   | Xoofff_Expand         |
+| Flag for Last Part        | KRAVATTE_FLAG_LAST_PART | Xoofff_FlagLastPart   |
+
+### SANE mode (Authenticated Encryption)
+
+| Feature             | Kravatte SANE            | Xoofff SANE           |
+| ------------------- | ------------------------ | --------------------- |
+| Header              | "KravatteModes.h"        | "XoofffModes.h"       |
+| Instance Type       | Kravatte_SANE_Instance   | XoofffSANE_Instance   |
+| Initialization      | Kravatte_SANE_Initialize | XoofffSANE_Initialize |
+| Wrapping Function   | Kravatte_SANE_Wrap       | XoofffSANE_Wrap       |
+| Unwrapping Function | Kravatte_SANE_Unwrap     | XoofffSANE_Unwrap     |
+| Tag Length          | Kravatte_SANE_TagLength  | XoofffSANE_TagLength  |
+
+### SANSE mode (Authenticated Encryption)
+
+| Feature             | Kravatte SANSE            | Xoofff SANSE           |
+| ------------------- | ------------------------- | ---------------------- |
+| Header              | "KravatteModes.h"         | "XoofffModes.h"        |
+| Instance Type       | Kravatte_SANSE_Instance   | XoofffSANSE_Instance   |
+| Initialization      | Kravatte_SANSE_Initialize | XoofffSANSE_Initialize |
+| Wrapping Function   | Kravatte_SANSE_Wrap       | XoofffSANSE_Wrap       |
+| Unwrapping Function | Kravatte_SANSE_Unwrap     | XoofffSANSE_Unwrap     |
+| Tag Length          | Kravatte_SANSE_TagLength  | XoofffSANSE_TagLength  |
+
+### WBC
+
+| Feature           | Kravatte WBC            | Xoofff WBC           |
+| ----------------- | ----------------------- | -------------------- |
+| Header            | "KravatteModes.h"       | "XoofffModes.h"      |
+| Instance Type     | Kravatte_Instance       | Xoofff_Instance      |
+| Initialization    | Kravatte_WBC_Initialize | XoofffWBC_Initialize |
+| Encipher Function | Kravatte_WBC_Encipher   | XoofffWBC_Encipher   |
+| Decipher Function | Kravatte_WBC_Decipher   | XoofffWBC_Decipher   |
+
+### WBC-AE
+
+| Feature           | Kravatte WBC-AE           | Xoofff WBC-AE          |
+| ----------------- | ------------------------- | ---------------------- |
+| Header            | "KravatteModes.h"         | "XoofffModes.h"        |
+| Instance Type     | Kravatte_Instance         | Xoofff_Instance        |
+| Initialization    | Kravatte_WBCAE_Initialize | XoofffWBCAE_Initialize |
+| Encipher Function | Kravatte_WBCAE_Encipher   | XoofffWBCAE_Encipher   |
+| Decipher Function | Kravatte_WBCAE_Decipher   | XoofffWBCAE_Decipher   |
+
 ## Xoodyak
+
+```
+
 ```

--- a/usage-example.md
+++ b/usage-example.md
@@ -411,155 +411,17 @@ while offering incremental properties on the input and output, helping in speedi
 
 ## Kravatte
 
-[//]: # (TODO: give some description about Kravatte)
+Kravatte is a deck function, on top of which we define simple modes:
 
-### Basic usages
+1. Kravatte-SANE: authenticated encryption supporting sessions
+2. Kravatte-SANSE: nonce-misuse resistant authenticated encryption supporting sessions
+3. Kravatte-WBC: wide block cipher
+4. Kravatte-WBC-AE: authenticated encryption
 
-<details open>
-<summary>Single input single output</summary>
+Kravatte is built upon the Keccak-p permutation, and the Farfalle construction, providing inherent parallelism that can be exploited on platforms supporting SIMD instructions or multiple cores.
 
-```c
- #include "Kravatte.h"
+In the following, we will give example usages of these modes.
 
- int main() {
-     // choose your key
-     const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
-
-     const unsigned char *input = (const unsigned char *) "a random input message";
-
-     Kravatte_Instance ki;
-     int result;
-
-     // initialize the Kravatte instance
-     result = Kravatte_MaskDerivation(&ki, key, strlen((const char *) key) * 8);
-     assert(result == 0);
-
-     int outputByteLen = 32;
-     unsigned char output[outputByteLen];
-
-     // one call to feed the input and get the output
-     result = Kravatte(&ki, input, strlen((const char *) input) * 8, output, outputByteLen * 8, 0);
-     assert(result == 0);
-
-     // printing the hash in hexadecimal format
-     for (int i = 0; i < outputByteLen; i++)
-        printf("\\x%02x", output[i]);
-     printf("\n");
-
-     // ...
- }
-````
-
-</details>
-
-<details open>
-    <summary>Advanced: Multiple input single output</summary>
-    We will feed the input in chunks, and get the output at once.
-
-```c
- #include "Kravatte.h"
-
- int main() {
-     const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
-
-     const int inputChunksCount = 4;
-     const unsigned char *input[inputChunksCount] = {
-         (const unsigned char *) "a ",
-         (const unsigned char *) "random ",
-         (const unsigned char *) "input ",
-         (const unsigned char *) "message"
-     };
-
-     const unsigned char *expectedOutput = (const unsigned char *)
-             "\xf9\x98\x1b\x67\x97\xbf\xf5\x45\xf5\xd1\xae\x6d\x33\x14\xb0\x99"
-             "\xcd\x9c\x5a\xcb\x52\xa4\x56\x69\xf7\xea\x52\xc8\x30\xf6\xb3\x7e";
-
-     Kravatte_Instance ki;
-     int result;
-
-     result = Kravatte_MaskDerivation(&ki, key,
-     strlen((const char *) key) * 8);
-     assert(result == 0);
-
-     // feeding the input in chunks
-     for (int i = 0; i < inputChunksCount; i++) {
-         int flags = (i == inputChunksCount - 1) ? KRAVATTE_FLAG_LAST_PART : 0;
-         result = Kra(&ki, input[i], strlen((const char *) input[i]) * 8, flags);
-         assert(result == 0);
-     }
-
-     int outputByteLen = 32;
-     unsigned char output[outputByteLen];
-
-     // getting the output at once
-     result = Vatte(&ki, output, outputByteLen * 8, KRAVATTE_FLAG_LAST_PART);
-     assert(result == 0);
-
-     // printing the output chunk in hexadecimal format
-     for (int i = 0; i < outputByteLen; i++)
-         printf("\\x%02x", output[i]);
-     printf("\n");
-
-     // ...
- }
-
-```
-
-</details>
-
-<details open>
-    <summary>Advanced: Single input multiple output</summary>
-    We will feed the input at once, and get the output in chunks.
-
-```c
- #include "Kravatte.h"
-
- int main() {
-     const unsigned char *key = (const unsigned char *) "alksjdfo2300a9sdflkjasdfdq343ag2";
-     const unsigned char *input = (const unsigned char *) "a random input message";
-
-     Kravatte_Instance ki;
-     int result;
-
-     result = Kravatte_MaskDerivation(&ki, key,
-     strlen((const char *) key) * 8);
-     assert(result == 0);
-
-     // feeding the input at once
-     result = Kra(&ki, input, strlen((const char *) input) * 8, KRAVATTE_FLAG_LAST_PART);
-     assert(result == 0);
-
-
-     const int outputChunksCount = 2;
-     const int outputChunkByteLen = 16;
-     unsigned char chunkOutput[outputChunkByteLen];
-
-     // initialize the full output
-     const int fullOutputByteLen = outputChunkByteLen * outputChunksCount;
-     unsigned char output[fullOutputByteLen];
-
-     // getting the output in chunks
-     for (int i = 0; i < outputChunksCount; i++) {
-         int flags = (i == outputChunksCount - 1) ? KRAVATTE_FLAG_LAST_PART : 0;
-         result = Vatte(&ki, chunkOutput, outputChunkByteLen * 8, flags);
-         assert(result == 0);
-         // incrementally build the output, like writing to a file.
-         // for simplicity, we use `memcpy` in this example:
-         memcpy(output + (i * outputChunkByteLen), chunkOutput, outputChunkByteLen);
-     }
-
-     // printing the output chunk in hexadecimal format
-     for (int i = 0; i < fullOutputByteLen; i++)
-         printf("\\x%02x", output[i]);
-     printf("\n");
-
-     // ...
- }
-```
-
-</details>
-    
-Those examples can be adapted to support multiple input multiple output as well, by using a sequence of `Kra` and `Vatte` calls.
 
 ### Kravatte-SANE authenticated encryption
 
@@ -921,18 +783,6 @@ Xoofff has an API similar to Kravatte, so the examples of Kravatte can be adapte
 In the following, we will give the differences between the APIs of Kravatte and Xoofff.
 
 One can use the below conversion tables to adapt the examples of Kravatte to use Xoofff.
-
-### Basic usages
-
-| Feature                   | Kravatte                | Xoofff                |
-| ------------------------- | ----------------------- | --------------------- |
-| Header                    | "Kravatte.h"            | "Xoofff.h"            |
-| Instance Type             | Kravatte_Instance       | Xoofff_Instance       |
-| Initialization            | Kravatte_MaskDerivation | Xoofff_MaskDerivation |
-| One call Hashing Function | Kravatte                | Xoofff                |
-| Input feeding Function    | Kra                     | Xoofff_Compress       |
-| Output Retrieval Function | Vatte                   | Xoofff_Expand         |
-| Flag for Last Part        | KRAVATTE_FLAG_LAST_PART | Xoofff_FlagLastPart   |
 
 ### Xoofff-SANE authenticated encryption
 

--- a/usage-example.md
+++ b/usage-example.md
@@ -907,6 +907,8 @@ int main() {
 }
 ```
 
+</details>
+
 ...
 
 ## Xoofff

--- a/usage-example.md
+++ b/usage-example.md
@@ -1270,14 +1270,14 @@ void testXoodyakKeyedSessionAuthenticatedEncryptionWithRollingSubKeys() {
     Xoodyak_Instance aliceInstanceSession1;
     Xoodyak_Instance bobInstanceSession1;
 
-    unsigned char aliceKey[16] = "o2jso2j!~l;aksj-";
-    unsigned char bobKey[16] = "o2jso2j!~l;aksj-";
+    unsigned char aliceKeySession1[16] = "o2jso2j!~l;aksj-";
+    unsigned char bobKeySession1[16] = "o2jso2j!~l;aksj-";
 
     // choose the same key for both instances
-    assert(memcmp(aliceKey, bobKey, 16) == 0);
+    assert(memcmp(aliceKeySession1, bobKeySession1, 16) == 0);
 
-    Xoodyak_Initialize(&aliceInstanceSession1, aliceKey, 16, NULL, 0, NULL, 0);
-    Xoodyak_Initialize(&bobInstanceSession1, bobKey, 16, NULL, 0, NULL, 0);
+    Xoodyak_Initialize(&aliceInstanceSession1, aliceKeySession1, 16, NULL, 0, NULL, 0);
+    Xoodyak_Initialize(&bobInstanceSession1, bobKeySession1, 16, NULL, 0, NULL, 0);
 
     unsigned char nonceSession1[16] = "#dojd983&72-21!@";
 
@@ -1287,11 +1287,15 @@ void testXoodyakKeyedSessionAuthenticatedEncryptionWithRollingSubKeys() {
 
     // now after we have initialized the instances of session 1,
     // we can derive the subkeys for session 2 and stored it for later.
-    Xoodyak_SqueezeKey(&aliceInstanceSession1, aliceKey, 16);
-    Xoodyak_SqueezeKey(&bobInstanceSession1, bobKey, 16);
 
-    // the new derived keys must be the same
-    assert(memcmp(aliceKey, bobKey, 16) == 0);
+    unsigned char aliceKeySession2[16];
+    unsigned char bobKeySession2[16];
+
+    Xoodyak_SqueezeKey(&aliceInstanceSession1, aliceKeySession2, 16);
+    Xoodyak_SqueezeKey(&bobInstanceSession1, bobKeySession2, 16);
+
+    // the new derived keys will be the same
+    assert(memcmp(aliceKeySession2, bobKeySession2, 16) == 0);
 
     // start of session 1 (note that we will not detail the usage of Xoodyak here, 
     // for a detailed example, see `testXoodyakKeyedSessionAuthenticatedEncryption`)
@@ -1324,8 +1328,8 @@ void testXoodyakKeyedSessionAuthenticatedEncryptionWithRollingSubKeys() {
     Xoodyak_Instance aliceInstanceSession2;
     Xoodyak_Instance bobInstanceSession2;
 
-    Xoodyak_Initialize(&aliceInstanceSession2, aliceKey, 16, NULL, 0, NULL, 0);
-    Xoodyak_Initialize(&bobInstanceSession2, bobKey, 16, NULL, 0, NULL, 0);
+    Xoodyak_Initialize(&aliceInstanceSession2, aliceKeySession2, 16, NULL, 0, NULL, 0);
+    Xoodyak_Initialize(&bobInstanceSession2, bobKeySession2, 16, NULL, 0, NULL, 0);
 
     unsigned char nonceSession2[16] = "#dojd923572-21!@";
 


### PR DESCRIPTION
A documentation page showing in simple steps the way to use different cryptographic functions provided by XKCP in users' C code.

Todo:
- [x] Add examples of how to feed input in chunks, and squeeze output in chunks (for FIPS-202 functions)
- [x] Add examples for TurboSHAKE
- [x] Add examples for KangarooTwelve
- [x] Add examples for Kravatte and its modes
- [x] Add examples for Xoofff and its modes
- [x] Add examples for Xoodyak