### PR TITLE
Add a CI to XKCP, with native as well as cross-compilation tests (com…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: XKCP CI
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize submodules
+      run: git submodule update --init --recursive
+
+    - name: Build and test
+      id: build-image
+      env:
+        CI_VERBOSE: 1
+        # For now, platforms other than x86 and ARM are not activated in the CI
+        # (this concerns mips(el),mips64(el), sparc64, riscv64)
+        # This is not active as XKCP endianness and memory alignment issues must
+        # be resolved in all the low-level layers: once done, this environment
+        # variable can be set to 1.
+        OTHER_PLATFORMS: 0
+      run: |
+        make -f Makefile.ci

--- a/CI/Dockerfile.ci
+++ b/CI/Dockerfile.ci
@@ -1,0 +1,71 @@
+FROM debian:bookworm-slim AS builder
+ARG OTHER_PLATFORMS
+ENV OTHER_PLATFORMS $OTHER_PLATFORMS
+
+RUN if [ "$OTHER_PLATFORMS" = 1 ]; then apt-get update        && \
+    apt-get install -qy --no-install-recommends                     \
+        make                                                        \
+        gcc                                                         \
+        gcc-multilib-i686-linux-gnu                                 \
+        libc6-dev-armel-cross                                       \
+        libc6-dev-arm64-cross                                       \
+        gcc-mingw-w64-x86-64                                        \
+        gcc-mingw-w64-i686-win32                                    \
+        gcc-arm-linux-gnueabi                                       \
+        gcc-arm-none-eabi                                           \
+        gcc-aarch64-linux-gnu                                       \
+        qemu-user-static                                            \
+        qemu-system-arm                                             \
+        picolibc-arm-none-eabi                                      \
+        xsltproc                                                    \
+        wine                                                        \
+        xvfb                                                        \
+        gcc-sparc64-linux-gnu                                       \
+        libc6-dev-sparc-sparc64-cross                               \
+        gcc-mips-linux-gnu                                          \
+        gcc-mipsel-linux-gnu                                        \
+        gcc-mips64-linux-gnuabi64                                   \
+        gcc-mips64el-linux-gnuabi64                                 \
+        libc6-dev-mips-cross                                        \
+        libc6-dev-mips32-mips64-cross                               \
+        libc6-dev-mipsel-cross                                      \
+        libc6-dev-mips64-cross                                      \
+        libc6-dev-mips64-mipsel-cross                               \
+        libc6-dev-mips64el-cross                                    \
+        gcc-riscv64-linux-gnu                                       \
+        libc6-dev-riscv64-cross                                     \
+        clang                                                    && \
+    dpkg --add-architecture i386                                 && \
+    apt-get update                                               && \
+    apt-get install -qy --no-install-recommends wine32:i386      && \
+    apt-get clean                                                && \
+    rm -rf /var/lib/apt/lists/; else                                \
+    apt-get update                                               && \
+    apt-get install -qy --no-install-recommends                     \
+        make                                                        \
+        gcc                                                         \
+        gcc-multilib-i686-linux-gnu                                 \
+        libc6-dev-armel-cross                                       \
+        libc6-dev-arm64-cross                                       \
+        gcc-mingw-w64-x86-64                                        \
+        gcc-mingw-w64-i686-win32                                    \
+        gcc-arm-linux-gnueabi                                       \
+        gcc-arm-none-eabi                                           \
+        gcc-aarch64-linux-gnu                                       \
+        qemu-user-static                                            \
+        qemu-system-arm                                             \
+        picolibc-arm-none-eabi                                      \
+        xsltproc                                                    \
+        wine                                                        \
+        xvfb                                                        \
+        clang                                                    && \
+    dpkg --add-architecture i386                                 && \
+    apt-get update                                               && \
+    apt-get install -qy --no-install-recommends wine32:i386      && \
+    apt-get clean                                                && \
+    rm -rf /var/lib/apt/lists/; fi
+
+WORKDIR /build
+COPY ./ ./
+COPY ./CI/ci_tests.sh ./
+RUN sh ci_tests.sh

--- a/CI/Dockerfile.ci
+++ b/CI/Dockerfile.ci
@@ -68,4 +68,7 @@ RUN if [ "$OTHER_PLATFORMS" = 1 ]; then apt-get update        && \
 WORKDIR /build
 COPY ./ ./
 COPY ./CI/ci_tests.sh ./
+# NOTE: the random forces a Docker cache miss to force
+# the execution of the script
+ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
 RUN sh ci_tests.sh

--- a/CI/ci_tests.sh
+++ b/CI/ci_tests.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+
+set -e
+
+## For wine to be quiet when trying to use an external DISPLAY
+Xvfb :1 &
+export DISPLAY=:1
+
+## NOTE: for now, this is not activated by default (OTHER_PLATFORMS=1 must be forced).
+## This is due to the fact that for now, XKCP does not pass the tests on these platforms because
+## of either endianness issues (missing macros) or alignment issues (see issue #124).
+if [ "$OTHER_PLATFORMS" = "1" ]; then
+	# Non-x86 and non-ARM platforms little endian platforms (big endian not supported yet for all the functions in XKCP)
+	echo "\n\n\n=========== Switching to cross-compilation of generic impletation on non-x86 and non-ARM platforms\n\n\n"
+	for t in generic32 generic32lc generic64 generic64lc; do
+		for c in mips-linux-gnu-gcc mipsel-linux-gnu-gcc sparc64-linux-gnu-gcc mips64-linux-gnuabi64-gcc mips64el-linux-gnuabi64-gcc riscv64-linux-gnu-gcc; do
+		arch=`echo -n $c | cut -d'-' -f1`
+		echo "\n\n\n=========== Compiling with $t with $c compiler for architecture $arch\n\n\n"
+		make clean && CC=$c NO_FLAGS_NATIVE=1 EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+		echo "\n\n\n=========== Testing $t (compiled with $c compiler) for architecture $arch\n\n\n"
+		qemu-$arch-static ./bin/$t/UnitTests -p
+		done
+	done
+else
+	echo "\n\n\nSkipping non-x86 and non-ARM platforms, as OTHER_PLATFORMS has not been defined ...\n\n\n"
+fi
+
+## x86_64 targets using the local host compiler (gcc or clang)
+for t in generic32 generic32lc generic64 generic64lc SSSE3 AVX AVX2 AVX2noAsm AVX512 AVX512noAsm; do
+	for c in gcc clang x86_64-w64-mingw32-gcc; do
+		echo "=========== Compiling $t (with $c compiler)\n\n\n"
+		make clean && CC=$c make $t/UnitTests -j`nproc`
+		# NOTE: AVX512 is not supported by Qemu as of now, so do not test them
+		if echo "$t" | grep -q "AVX512"; then
+			echo "\n\n\n=========== Skipping run test for $t (compiled with $c compiler): AVX512 not supported yet by Qemu (and not supported by native CI CPUs)\n\n\n"
+		else
+			if echo "$c" | grep -q "mingw"; then
+				# NOTE: for mingw targets, it is complicated to emulate non generic instruction set on any CPU
+				if echo "$t" | grep -q "generic"; then
+					echo "\n\n\n=========== Testing $t (compiled with $c compiler) for x86_64 windows\n\n\n"
+					echo "============== (emulating with wine)"
+					wine ./bin/$t/UnitTests.exe -p
+				fi
+			else
+				echo "\n\n\n=========== Testing $t (compiled with $c compiler) for x86_64\n\n\n"
+				qemu-x86_64-static ./bin/$t/UnitTests -p
+			fi
+		fi
+	done
+done
+
+## x86 32 bits targets on generic implementations
+for t in generic32 generic32lc generic64 generic64lc; do
+	for c in i686-linux-gnu-gcc i686-w64-mingw32-gcc; do
+		echo "=========== Compiling $t (with $c compiler)\n\n\n"
+		make clean && CC=$c EXTRA_CFLAGS="-static" make $t/UnitTests -j`nproc`
+		if echo "$c" | grep -q "mingw"; then
+			# NOTE: for mingw targets, it is complicated to emulate non generic instruction set on any CPU
+			if echo "$t" | grep -q "generic"; then
+				echo "\n\n\n=========== Testing $t (compiled with $c compiler) for i386 windows\n\n\n"
+				echo "============== (emulating with wine)"
+				wine ./bin/$t/UnitTests.exe -p
+			fi
+		else
+			echo "\n\n\n=========== Testing $t (compiled with $c compiler) for i386\n\n\n"
+			qemu-i386-static ./bin/$t/UnitTests -p
+		fi
+	done
+done
+
+echo "\n\n\n=========== Switching to cross-compilation of C variants for ARM Cortex-A platforms\n\n\n"
+for t in generic32 generic32lc generic64 generic64lc; do
+	# ARM v6A
+	echo "\n\n\n=========== Compiling $t/UnitTests for ARM v6A\n\n\n"
+	make clean && CC="arm-linux-gnueabi-gcc" EXTRA_CFLAGS="-march=armv6 -mtune=arm1136j-s" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+	# NOTE: there is a bus error with generic64(lc) for now, see issue #124 (https://github.com/XKCP/XKCP/issues/124)
+	# Hence, we deactivate the unit tests for this specific case.
+	if echo "$t" | grep -q "generic64"; then
+		true
+	else
+		echo "\n\n\n=========== Testing $t/UnitTests with Qemu for ARM v6A\n\n\n"
+		qemu-arm-static ./bin/$t/UnitTests -p
+	fi
+	# ARM v7A
+	echo "\n\n\n=========== Compiling $t/UnitTests for ARM v7A\n\n\n"
+	make clean && CC="arm-linux-gnueabi-gcc" EXTRA_CFLAGS="-march=armv7-a -mtune=cortex-a15" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+	# NOTE: there is a bus error with generic64(lc) for now, see issue #124 (https://github.com/XKCP/XKCP/issues/124)
+	# Hence, we deactivate the unit tests for this specific case.
+	if echo "$t" | grep -q "generic64"; then
+		true
+	else
+		echo "\n\n\n=========== Testing $t/UnitTests with Qemu for ARM v7A\n\n\n"
+		qemu-arm-static ./bin/$t/UnitTests -p
+	fi
+	# ARM 64
+	echo "\n\n\n=========== Compiling $t/UnitTests for ARM v8A (aarch64)\n\n\n"
+	make clean && CC="aarch64-linux-gnu-gcc" EXTRA_CFLAGS="-march=armv8.6-a -mtune=cortex-a75" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+	echo "\n\n\n=========== Testing $t/UnitTests with Qemu for  ARM v8A (aarch64)\n\n\n"
+	qemu-aarch64-static ./bin/$t/UnitTests -p
+done
+
+echo "\n\n\n=========== Switching to cross-compilation of assembly optimized variants for ARM Cortex-A platforms\n\n\n"
+### ARM A
+# ARM v6A
+t="ARMv6"
+echo "\n\n\n=========== Compiling $t/UnitTests\n\n\n"
+make clean && CC="arm-linux-gnueabi-gcc" EXTRA_CFLAGS="-march=armv6 -mtune=arm1136j-s" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+echo "\n\n\n=========== Testing $t/UnitTests with Qemu\n\n\n"
+qemu-arm-static ./bin/$t/UnitTests -p
+# ARM v7A
+t="ARMv7A"
+echo "\n\n\n=========== Compiling $t/UnitTests\n\n\n"
+make clean && CC="arm-linux-gnueabi-gcc" EXTRA_CFLAGS="-march=armv7-a -mtune=cortex-a15" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+echo "\n\n\n=========== Testing $t/UnitTests with Qemu\n\n\n"
+qemu-arm-static ./bin/$t/UnitTests -p
+# ARM v8A with aarch64
+t="ARMv8A"
+echo "\n\n\n=========== Compiling $t/UnitTests\n\n\n"
+make clean && CC="aarch64-linux-gnu-gcc" EXTRA_CFLAGS="-march=armv8.6-a -mtune=cortex-a75" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+echo "\n\n\n=========== Testing $t/UnitTests with Qemu\n\n\n"
+qemu-aarch64-static ./bin/$t/UnitTests -p
+
+
+echo "\n\n\n=========== Switching to cross-compilation of C and assembly optimized variants for ARM Cortex-M platforms\n\n\n"
+### ARM M dedicated compilations: they need special care as we test them with semi-hosting qemu-system
+## NOTE: we use some trick to force Qemu in semi-hosting mode to exit, as well as patch the call to "process" with the appropriate arguments
+## as args are note taken by qemu-system
+awk '/#include/ && !done { print "#include \"../../CI/qemu_semihosting_exit.h\""; done=1;}; 1;' tests/UnitTests/main.c > /tmp/main.c
+sed -i 's/return process(argc, argv);/    char *args[] = {"", "-p"}; process(2, args); _exit_qemu();/' /tmp/main.c
+mv /tmp/main.c tests/UnitTests/main.c
+
+## NOTE: we would want to compile and test all the generic C code on the microcontrollers. However, some of them have some issues
+## to be investigated. Hence, we only compile and test the ARMv6M and ARMv7M assembly versions.
+#
+#for t in generic32 generic32lc generic64 generic64lc ARMv6M ARMv7M; do
+#
+for t in ARMv6M ARMv7M; do
+	if echo "$t" | grep -q "ARMv7M"; then
+		true
+	else
+		echo "\n\n\n=========== Compiling $t/UnitTests for ARMv6M microcontrollers\n\n\n"
+		make clean && CC="arm-none-eabi-gcc" EXTRA_CFLAGS="-march=armv6-m -mtune=cortex-m0 -specs=picolibc.specs --oslib=semihost -TCI/cortexm_layout.ld" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+		echo "\n\n\n=========== Testing $t/UnitTests with Qemu-system semi-hosting\n\n\n"
+		qemu-system-arm -semihosting-config enable=on -monitor none -serial none -nographic -machine mps2-an385,accel=tcg -no-reboot -kernel ./bin/$t/UnitTests
+	fi
+	##
+	if echo "$t" | grep -q "ARMv6M"; then
+		true
+	else
+		echo "\n\n\n=========== Compiling $t/UnitTests for ARMv7M microcontrollers\n\n\n"
+		make clean && CC="arm-none-eabi-gcc" EXTRA_CFLAGS="-march=armv7-m -mtune=cortex-m3 -specs=picolibc.specs --oslib=semihost -TCI/cortexm_layout.ld" EXTRA_ASMFLAGS=$EXTRA_CFLAGS EXTRA_LDFLAGS="-static" make $t/UnitTests -j`nproc`
+		echo "\n\n\n=========== Testing $t/UnitTests with Qemu-system semi-hosting\n\n\n"
+		qemu-system-arm -semihosting-config enable=on -monitor none -serial none -nographic -machine mps2-an385,accel=tcg -no-reboot -kernel ./bin/$t/UnitTests
+	fi
+done

--- a/CI/cortexm_layout.ld
+++ b/CI/cortexm_layout.ld
@@ -1,0 +1,7 @@
+__flash =      0x00000000;
+__flash_size = 0x00100000;
+__ram =        0x20000000;
+__ram_size   = 0x00010000;
+__stack_size = 1k;
+
+INCLUDE picolibc.ld

--- a/CI/qemu_semihosting_exit.h
+++ b/CI/qemu_semihosting_exit.h
@@ -1,0 +1,12 @@
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+// Function injected to exit Qemu semi-hosting mode
+// on Cortex-M MCUs
+static inline void _exit_qemu(void) {
+    register unsigned int r0 __asm__("r0");
+    r0 = 0x18;
+    register unsigned int r1 __asm__("r1");
+    r1 = 0x20026;
+    __asm__ volatile("bkpt #0xAB");
+}
+#pragma GCC pop_options

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,0 +1,13 @@
+ifeq ($(CI_FORCE_REBUILD),1)
+NOCACHE=--no-cache
+RECREATE=--force-recreate
+else
+NOCACHE=
+RECREATE=
+endif
+ifeq ($(CI_VERBOSE),1)
+BUILDKIT_PROGRESS=plain
+endif
+
+all:
+	DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=$(BUILDKIT_PROGRESS) docker build $(NOCACHE) --build-arg OTHER_PLATFORMS=$(OTHER_PLATFORMS) --file CI/Dockerfile.ci .


### PR DESCRIPTION
…pilation

and unit tests).

The rationale of the CI script is to:
- Cross-compile all the possible targets
- Run them using Qemu in user mode (for both x86 and native x86) or Wine (for native windows mingw cross-compilation).

Even the microcontrollers ARM Cortex-M variants are cross-compiled and tested (using Qemu in system mode and semi-hosting).

For now, only the `UnitTests -p` toggle is used as the `-a` toggle takes too much time.

The CI can be run independently from github runners as it is a dedicated Docker. Just run (with docker installed of course) at the root folder:

`$ CI_VERBOSE=1 make -f Makefile.ci`

(since native builds are executed with wine here, users of Mac M1 / ARM should expect some issues with these: future updates of the CI script could detect this and avoid Wine in this case. Anyway, CI should work on any x86 plarform).