### PR TITLE
[NFCI] Move Keccak rhotates tables to rodata

### DIFF
--- a/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
+++ b/lib/low/KeccakP-1600/AVX2/KeccakP-1600-AVX2.s
@@ -1014,6 +1014,9 @@ KeccakP1600_12rounds_FastLoop_Absorb_LanesAddLoop:
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
 .endif
 
+.ifndef old_gas_syntax
+.section .rodata
+.endif
 .equ    ALLON,        0xFFFFFFFFFFFFFFFF
 
 .balign 64


### PR DESCRIPTION
rhotates tables are added to .text section which confuses tools such as
BOLT. Move them to rodata to unbreak and avoid polluting icache/iTLB
with data.

Fix in OpenSSL openssl/openssl#21440
