### PR TITLE
KT256 standalone python implementation

### DIFF
--- a/Standalone/KangarooTwelve/Python/K12-SIMD-simulation.py
+++ b/Standalone/KangarooTwelve/Python/K12-SIMD-simulation.py
@@ -89,7 +89,7 @@ The granularity is the lane (64 bits).
 For the first state, we take the 8*laneCount bytes at data[0 : 8*laneCount] and add them to it.
 For the second state, we take 8*laneCount bytes 8*laneOffset bytes further, so at data[8*laneOffset : 8*laneOffset + 8*laneCount], and add them to it.
 For the third state, we do the same, but again 8*laneOffset bytes further, etc.
-For KT128 (and KT256), 8*laneOffset is 8192 so that the first state gets data from the first leaf, the second state from the second leaf, etc.
+For KT128 and KT256, 8*laneOffset is 8192 so that the first state gets data from the first leaf, the second state from the second leaf, etc.
 
 Parameters
 ----------

--- a/Standalone/KangarooTwelve/Python/K12-SIMD-simulation.py
+++ b/Standalone/KangarooTwelve/Python/K12-SIMD-simulation.py
@@ -288,6 +288,7 @@ def KT128(inputMessage, customizationString, outputByteLen):
             + right_encode(n) + b'\xFF\xFF'
         return TurboSHAKE128(NodeStar, 0x06, outputByteLen)
     
+
 def KT256(inputMessage, customizationString, outputByteLen):
     c = 512
     # Concatenate the input message, the customization string and the length of the latter
@@ -326,7 +327,6 @@ def KT256(inputMessage, customizationString, outputByteLen):
         NodeStar = S[0:B] + bytearray([3,0,0,0,0,0,0,0]) + CVs \
             + right_encode(n) + b'\xFF\xFF'
         return TurboSHAKE256(NodeStar, 0x06, outputByteLen)
-
 
 
 # Test that KeccakP1600timesN_SIMD does what it is supposed to
@@ -377,6 +377,9 @@ def printK12TestVectors():
         print("KangarooTwelve(M={0:d} times byte 0xFF, C=pattern 0x00 to 0xFA for 41^{1:d} bytes, 32 output bytes):".format(2**i-1, i))
         outputHex(KT128(M, C, 32))
 
+
+# for testing reasons, inspired by the test vectors of the update KangarooTwelve draft
+# https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-kangarootwelve
 def ptn(n):
     pattern = bytes(range(0xFA + 1))  # Include 0xFA
     repetitions = n // len(pattern)
@@ -384,10 +387,10 @@ def ptn(n):
     repeated_pattern = pattern * repetitions + pattern[:remainder]
     return repeated_pattern
 
+
 # outputHex(KT256(b'', b'', 64))
 # print()
 # outputHex(KT256(b'', b'', 128))
-
 # outputHex(KT256(ptn(17), b'', 64))
 # print()
 # outputHex(KT256(ptn(17**2), b'', 64))
@@ -411,6 +414,6 @@ def ptn(n):
 # outputHex(KT256(ptn(8192), ptn(8190), 64))
 
 
-# Test_KeccakP1600timesN_SIMD()
-# Test_KangarooTwelve_ProcessLeaves_128()
-# printK12TestVectors()
+Test_KeccakP1600timesN_SIMD()
+Test_KangarooTwelve_ProcessLeaves_128()
+printK12TestVectors()

--- a/Standalone/KangarooTwelve/Python/K12-SIMD-simulation.py
+++ b/Standalone/KangarooTwelve/Python/K12-SIMD-simulation.py
@@ -9,7 +9,7 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 """
-The Python code in this module illustrates how KangarooTwelve (K12) can be implemented using single-instruction-multiple-data (SIMD) instructions.
+The Python code in this module illustrates how the KangarooTwelve variations, KT128 and KT256, can be implemented using single-instruction-multiple-data (SIMD) instructions.
 It does not provide optimized SIMD code, but instead illustrates how one can write SIMD code for K12 by simulating how SIMD works.
 As a convention, it simulates SIMD registers of N×64 bits, for some positive integer N, by putting the N words of 64 bits in a list.
 For instance, 256-bit SIMD instructions like AVX2 work on N=4 words of 64 bits.
@@ -89,7 +89,6 @@ The granularity is the lane (64 bits).
 For the first state, we take the 8*laneCount bytes at data[0 : 8*laneCount] and add them to it.
 For the second state, we take 8*laneCount bytes 8*laneOffset bytes further, so at data[8*laneOffset : 8*laneOffset + 8*laneCount], and add them to it.
 For the third state, we do the same, but again 8*laneOffset bytes further, etc.
-// NOTE: important
 For KT128 (and KT256), 8*laneOffset is 8192 so that the first state gets data from the first leaf, the second state from the second leaf, etc.
 
 Parameters
@@ -173,7 +172,6 @@ def KangarooTwelve_ProcessLeaves_128(N, data):
         # - add bytes data[j : j + 168] to the first state
         # - add bytes data[8KiB + j : 8KiB + j + 168] to the second state
         # - add bytes data[16KiB + j : 16KiB + j + 168] to the third state, etc.
-        # Note: the last param is offset in lanes, not in bytes, thus the //8
         KeccakP1600timesN_AddLanesAll(N, A, data[j:], rateInLanes, B//8) 
         # Apply Keccak-p[1600, 12 rounds] to all states
         A = KeccakP1600timesN_SIMD(N, A, 12)
@@ -360,21 +358,21 @@ def outputHex(s):
 
 # Produce test vectors
 def printK12TestVectors():
-    print("KangarooTwelve(M=empty, C=empty, 32 output bytes):")
+    print("KT128(M=empty, C=empty, 32 output bytes):")
     outputHex(KT128(b'', b'', 32))
-    print("KangarooTwelve(M=empty, C=empty, 64 output bytes):")
+    print("KT128(M=empty, C=empty, 64 output bytes):")
     outputHex(KT128(b'', b'', 64))
-    print("KangarooTwelve(M=empty, C=empty, 10032 output bytes), last 32 bytes:")
+    print("KT128(M=empty, C=empty, 10032 output bytes), last 32 bytes:")
     outputHex(KT128(b'', b'', 10032)[10000:])
     for i in range(6):
         C = b''
         M = bytearray([(j % 251) for j in range(17**i)])
-        print("KangarooTwelve(M=pattern 0x00 to 0xFA for 17^{0:d} bytes, C=empty, 32 output bytes):".format(i))
+        print("KT128(M=pattern 0x00 to 0xFA for 17^{0:d} bytes, C=empty, 32 output bytes):".format(i))
         outputHex(KT128(M, C, 32))
     for i in range(4):
         M = bytearray([0xFF for j in range(2**i-1)])
         C = bytearray([(j % 251) for j in range(41**i)])
-        print("KangarooTwelve(M={0:d} times byte 0xFF, C=pattern 0x00 to 0xFA for 41^{1:d} bytes, 32 output bytes):".format(2**i-1, i))
+        print("KT128(M={0:d} times byte 0xFF, C=pattern 0x00 to 0xFA for 41^{1:d} bytes, 32 output bytes):".format(2**i-1, i))
         outputHex(KT128(M, C, 32))
 
 


### PR DESCRIPTION
This PR adapts the standalone python KangarooTwelve to work with the [new proposed KT256](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-kangarootwelve)

The newly added code was tested with the [test vectors](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-kangarootwelve) to confirm its correctness.

Note that the PR is not in its cleanest state :) For simplicity, I have opted for duplicating the code instead of reusing what's existing, I will revisit it soon to see if some relevant refactors can be made. Suggestions are most welcome. 