### PR TITLE
Fixes Visual Studio build

### DIFF
--- a/lib/high/Kravatte/Kravatte.h
+++ b/lib/high/Kravatte/Kravatte.h
@@ -50,20 +50,24 @@ typedef enum
 
 #if defined(XKCP_has_KeccakP1600times8)
     #define KravatteMaxParallellism   8
+    #define KravatteAlignment         64
 #elif defined(XKCP_has_KeccakP1600times4)
     #define KravatteMaxParallellism   4
+    #define KravatteAlignment         32
 #elif defined(XKCP_has_KeccakP1600times2)
     #define KravatteMaxParallellism   2
+    #define KravatteAlignment         16
 #else
     #define KravatteMaxParallellism   1
+    #define KravatteAlignment         8
 #endif
 
 typedef struct {
-    ALIGN(KravatteMaxParallellism*8) uint8_t k[200];
-    ALIGN(KravatteMaxParallellism*8) uint8_t kRoll[200];
-    ALIGN(KravatteMaxParallellism*8) uint8_t xAccu[200];
-    ALIGN(KravatteMaxParallellism*8) uint8_t yAccu[200];
-    ALIGN(KravatteMaxParallellism*8) uint8_t queue[200];    /* input/output queue buffer */
+    ALIGN(KravatteAlignment) uint8_t k[200];
+    ALIGN(KravatteAlignment) uint8_t kRoll[200];
+    ALIGN(KravatteAlignment) uint8_t xAccu[200];
+    ALIGN(KravatteAlignment) uint8_t yAccu[200];
+    ALIGN(KravatteAlignment) uint8_t queue[200];    /* input/output queue buffer */
     BitLength queueOffset;          /* current offset in queue */
     Kravatte_Phases phase;
 } Kravatte_Instance;

--- a/lib/high/Xoofff/Xoofff.c
+++ b/lib/high/Xoofff/Xoofff.c
@@ -377,7 +377,7 @@ size_t Xoofff_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kRoll, u
 
 static const unsigned char * Xoodoo_CompressBlocks( unsigned char *k, unsigned char *x, const BitSequence *message, BitLength *messageBitLen, int lastFlag )
 {
-    ALIGN(XoodooMaxParallellism*4) unsigned char encbuf[XoodooMaxParallellism*Xoofff_RollSizeInBytes];
+    ALIGN(XoodooAlignment) unsigned char encbuf[XoodooMaxParallellism*Xoofff_RollSizeInBytes];
     size_t messageByteLen = *messageBitLen / 8; /* do not include partial last byte */
 
     #if defined(XKCP_has_Xoodootimes16)
@@ -524,7 +524,7 @@ int Xoofff_Compress(Xoofff_Instance *xp, const BitSequence *input, BitLength inp
 int Xoofff_Expand(Xoofff_Instance *xp, BitSequence *output, BitLength outputBitLen, int flags)
 {
     size_t outputByteLen;
-    ALIGN(XoodooMaxParallellism*4) unsigned char encbuf[XoodooMaxParallellism*Xoofff_RollSizeInBytes];
+    ALIGN(XoodooAlignment) unsigned char encbuf[XoodooMaxParallellism*Xoofff_RollSizeInBytes];
     int finalFlag = flags & Xoofff_FlagLastPart;
 
     if ((finalFlag == 0) && ((outputBitLen & 7) != 0))

--- a/lib/high/Xoofff/Xoofff.h
+++ b/lib/high/Xoofff/Xoofff.h
@@ -51,29 +51,33 @@ typedef enum
 
 #if defined(XKCP_has_Xoodootimes16)
     #define XoodooMaxParallellism   16
+    #define XoodooAlignment         64
     #if defined(Xoodootimes16_FastXoofff_supported)
         #define    Xoofff_AddIs    Xooffftimes16_AddIs
     #endif
 #elif defined(XKCP_has_Xoodootimes8)
     #define XoodooMaxParallellism   8
+    #define XoodooAlignment         32
     #if defined(Xoodootimes8_FastXoofff_supported)
         #define    Xoofff_AddIs    Xooffftimes8_AddIs
     #endif
 #elif defined(XKCP_has_Xoodootimes4)
     #define XoodooMaxParallellism   4
+    #define XoodooAlignment         16
     #if defined(Xoodootimes4_FastXoofff_supported)
         #define    Xoofff_AddIs    Xooffftimes4_AddIs
     #endif
 #else
     #define XoodooMaxParallellism   1
+    #define XoodooAlignment         4
 #endif
 
 typedef struct {
-    ALIGN(XoodooMaxParallellism*4) uint8_t k[48];
-    ALIGN(XoodooMaxParallellism*4) uint8_t kRoll[48];
-    ALIGN(XoodooMaxParallellism*4) uint8_t xAccu[48];
-    ALIGN(XoodooMaxParallellism*4) uint8_t yAccu[48];
-    ALIGN(XoodooMaxParallellism*4) uint8_t queue[48];     /* input/output queue buffer */
+    ALIGN(XoodooAlignment) uint8_t k[48];
+    ALIGN(XoodooAlignment) uint8_t kRoll[48];
+    ALIGN(XoodooAlignment) uint8_t xAccu[48];
+    ALIGN(XoodooAlignment) uint8_t yAccu[48];
+    ALIGN(XoodooAlignment) uint8_t queue[48];     /* input/output queue buffer */
     BitLength queueOffset;          /* current offset in queue */
     Xoofff_Phases phase;
 } Xoofff_Instance;


### PR DESCRIPTION
__declspec(align(x)) does not support arbitrary compile-time expressions for 'x'.  It supports only a predefined list of integer values.