### PR TITLE
Fix missing return statements 

### DIFF
--- a/lib/low/x86-64-dispatch/x86-64-dispatch.c
+++ b/lib/low/x86-64-dispatch/x86-64-dispatch.c
@@ -1043,7 +1043,7 @@ void Xoofff_AddIs(unsigned char *output, const unsigned char *input, size_t bitL
 size_t Xoofff_CompressFastLoop(unsigned char *kRoll, unsigned char *xAccu, const unsigned char *input, size_t length)
 {
     if (XKCP_enableAVX512)
-        Xoofff_AVX512_CompressFastLoop(kRoll, xAccu, input, length);
+        return Xoofff_AVX512_CompressFastLoop(kRoll, xAccu, input, length);
     else
         assert(0);
 }
@@ -1051,7 +1051,7 @@ size_t Xoofff_CompressFastLoop(unsigned char *kRoll, unsigned char *xAccu, const
 size_t Xoofff_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kRoll, unsigned char *output, size_t length)
 {
     if (XKCP_enableAVX512)
-        Xoofff_AVX512_ExpandFastLoop(yAccu, kRoll, output, length);
+        return Xoofff_AVX512_ExpandFastLoop(yAccu, kRoll, output, length);
     else
         assert(0);
 }


### PR DESCRIPTION
While testing the latest build of XKCP with runtime dispatch, we encountered some build errors in our environment with `-Wall -Werror -Wpedantic`. We were alerted to a couple methods that are not returning any values despite declaring a return type.  