### PR TITLE
Fix: DeckBO self-test misses decrypted plaintext check

### DIFF
--- a/tests/UnitTests/testShakingUpAE.c
+++ b/tests/UnitTests/testShakingUpAE.c
@@ -131,7 +131,7 @@ static void testDeckBO( int turbo, uint32_t c )
                 rv = SHAKE_BO_Unwrap( &dbou, P2, A, Alen, C, Plen + taglen );
             }
             assert(rv == 0);
-            memcmp( P, P2, Plen );
+            rv = memcmp( P, P2, Plen );
             assert(rv == 0);
         }
     }


### PR DESCRIPTION
The committed DeckBO unit test discards the plaintext comparison result, so it can report success even when `SHAKE_BO_Unwrap()` or `TurboSHAKE_BO_Unwrap()` returns incorrect plaintext.

This exploration and report were automatically generated by the Swival Security Scanner (https://swival.dev) using opensource models.