### PR TITLE
Runtime dispatch: detect CPU features automatically

### DIFF
--- a/lib/low/aarch64-dispatch/aarch64-dispatch.c
+++ b/lib/low/aarch64-dispatch/aarch64-dispatch.c
@@ -72,6 +72,30 @@ void XKCP_SetProcessorCapabilities(void)
     XKCP_enableSHA3 = aarch64_has_sha3() && !XKCP_SHA3_requested_disabled;
 }
 
+/* Run the detection once, on first use. Re-running it later is harmless:
+   XKCP_SetProcessorCapabilities() is idempotent and honors the
+   XKCP_*_requested_disabled flags set by the XKCP_Disable*() functions. */
+static void XKCP_EnsureProcessorCapabilities(void)
+{
+    static int done = 0;
+    if (!done) {
+        XKCP_SetProcessorCapabilities();
+        done = 1;
+    }
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+/* Run the detection before main() (or when a shared library is loaded), while
+   the process is still single-threaded, so that multithreaded applications do
+   not race on the first-use detection above. The lazy calls in the dispatchers
+   remain as a fallback for toolchains without constructor support. */
+__attribute__((constructor))
+static void XKCP_InitializeProcessorCapabilities(void)
+{
+    XKCP_EnsureProcessorCapabilities();
+}
+#endif
+
 void XKCP_EnableAllCpuFeatures(void)
 {
     XKCP_SHA3_requested_disabled = 0;
@@ -103,6 +127,7 @@ int XKCP_ProcessCpuFeatureCommandLineOption(const char *arg)
 
 const char * KeccakP1600_GetImplementation(void)
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableSHA3)
         return KeccakP1600_v84a_GetImplementation();
     else
@@ -111,17 +136,13 @@ const char * KeccakP1600_GetImplementation(void)
 
 int KeccakP1600_GetFeatures(void)
 {
+    XKCP_EnsureProcessorCapabilities();
     return KeccakP1600_plain64_GetFeatures();
 }
 
 void KeccakP1600_StaticInitialize(void)
 {
-    /* Detect once if the application did not already call EnableAllCpuFeatures. */
-    static int done = 0;
-    if (!done) {
-        XKCP_SetProcessorCapabilities();
-        done = 1;
-    }
+    XKCP_EnsureProcessorCapabilities();
 }
 
 /* Byte/lane management and 12-round permute are identical (generic 64-bit). */

--- a/lib/low/x86-64-dispatch/x86-64-dispatch.c
+++ b/lib/low/x86-64-dispatch/x86-64-dispatch.c
@@ -26,12 +26,37 @@ int XKCP_enableAVX2 = 0;
 int XKCP_enableAVX512 = 0;
 void XKCP_SetProcessorCapabilities(void);
 
+/* Run the detection once, on first use. Re-running it later is harmless:
+   XKCP_SetProcessorCapabilities() is idempotent and honors the
+   XKCP_*_requested_disabled flags set by the XKCP_Disable*() functions. */
+static void XKCP_EnsureProcessorCapabilities(void)
+{
+    static int done = 0;
+    if (!done) {
+        XKCP_SetProcessorCapabilities();
+        done = 1;
+    }
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+/* Run the detection before main() (or when a shared library is loaded), while
+   the process is still single-threaded, so that multithreaded applications do
+   not race on the first-use detection above. The lazy calls in the dispatchers
+   remain as a fallback for toolchains without constructor support. */
+__attribute__((constructor))
+static void XKCP_InitializeProcessorCapabilities(void)
+{
+    XKCP_EnsureProcessorCapabilities();
+}
+#endif
+
 #ifdef XKCP_has_KeccakP1600
 
 #include "KeccakP-1600-SnP.h"
 
 const char * KeccakP1600_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600_AVX512_GetImplementation();
     else if (XKCP_enableAVX2)
@@ -42,6 +67,7 @@ const char * KeccakP1600_GetImplementation()
 
 int KeccakP1600_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600_AVX512_GetFeatures();
     else if (XKCP_enableAVX2)
@@ -52,6 +78,7 @@ int KeccakP1600_GetFeatures()
 
 void KeccakP1600_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
 }
 
 void KeccakP1600_Initialize(KeccakP1600_state *state)
@@ -230,6 +257,7 @@ size_t KeccakP1600_12rounds_ODDuplexingFastIn(KeccakP1600_state *state, unsigned
 
 const char * KeccakP1600times2_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600times2_AVX512_GetImplementation();
     else if (XKCP_enableSSSE3)
@@ -240,6 +268,7 @@ const char * KeccakP1600times2_GetImplementation()
 
 int KeccakP1600times2_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600times2_AVX512_GetFeatures();
     else if (XKCP_enableSSSE3)
@@ -250,6 +279,7 @@ int KeccakP1600times2_GetFeatures()
 
 void KeccakP1600times2_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         KeccakP1600times2_AVX512_StaticInitialize();
     else if (XKCP_enableSSSE3)
@@ -468,6 +498,7 @@ void KeccakP1600times2_KT256ProcessLeaves(const unsigned char *input, unsigned c
 
 const char * KeccakP1600times4_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600times4_AVX512_GetImplementation();
     else if (XKCP_enableAVX2)
@@ -478,6 +509,7 @@ const char * KeccakP1600times4_GetImplementation()
 
 int KeccakP1600times4_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600times4_AVX512_GetFeatures();
     else if (XKCP_enableAVX2)
@@ -488,6 +520,7 @@ int KeccakP1600times4_GetFeatures()
 
 void KeccakP1600times4_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         KeccakP1600times4_AVX512_StaticInitialize();
     else if (XKCP_enableAVX2)
@@ -706,6 +739,7 @@ void KeccakP1600times4_KT256ProcessLeaves(const unsigned char *input, unsigned c
 
 const char * KeccakP1600times8_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600times8_AVX512_GetImplementation();
     else
@@ -714,6 +748,7 @@ const char * KeccakP1600times8_GetImplementation()
 
 int KeccakP1600times8_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return KeccakP1600times8_AVX512_GetFeatures();
     else
@@ -722,6 +757,7 @@ int KeccakP1600times8_GetFeatures()
 
 void KeccakP1600times8_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         KeccakP1600times8_AVX512_StaticInitialize();
     else
@@ -904,6 +940,7 @@ void KeccakP1600times8_KT256ProcessLeaves(const unsigned char *input, unsigned c
 
 const char * Xoodoo_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodoo_AVX512_GetImplementation();
     else if (XKCP_enableSSSE3)
@@ -914,6 +951,7 @@ const char * Xoodoo_GetImplementation()
 
 int Xoodoo_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodoo_AVX512_GetFeatures();
     else if (XKCP_enableSSSE3)
@@ -924,6 +962,7 @@ int Xoodoo_GetFeatures()
 
 void Xoodoo_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         Xoodoo_AVX512_StaticInitialize();
     else if (XKCP_enableSSSE3)
@@ -1124,6 +1163,7 @@ size_t Xoodyak_DecryptFullBlocks(Xoodoo_state *state, const uint8_t *I, uint8_t 
 
 const char * Xoodootimes4_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodootimes4_AVX512_GetImplementation();
     else if (XKCP_enableSSSE3)
@@ -1134,6 +1174,7 @@ const char * Xoodootimes4_GetImplementation()
 
 int Xoodootimes4_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodootimes4_AVX512_GetFeatures();
     else if (XKCP_enableSSSE3)
@@ -1144,6 +1185,7 @@ int Xoodootimes4_GetFeatures()
 
 void Xoodootimes4_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         Xoodootimes4_AVX512_StaticInitialize();
     else if (XKCP_enableSSSE3)
@@ -1314,6 +1356,7 @@ size_t Xooffftimes4_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kR
 
 const char * Xoodootimes8_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodootimes8_AVX512_GetImplementation();
     else if (XKCP_enableAVX2)
@@ -1324,6 +1367,7 @@ const char * Xoodootimes8_GetImplementation()
 
 int Xoodootimes8_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodootimes8_AVX512_GetFeatures();
     else if (XKCP_enableAVX2)
@@ -1334,6 +1378,7 @@ int Xoodootimes8_GetFeatures()
 
 void Xoodootimes8_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         Xoodootimes8_AVX512_StaticInitialize();
     else if (XKCP_enableAVX2)
@@ -1510,6 +1555,7 @@ size_t Xooffftimes8_ExpandFastLoop(unsigned char *yAccu, const unsigned char *kR
 
 const char * Xoodootimes16_GetImplementation()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodootimes16_AVX512_GetImplementation();
     else
@@ -1518,6 +1564,7 @@ const char * Xoodootimes16_GetImplementation()
 
 int Xoodootimes16_GetFeatures()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         return Xoodootimes16_AVX512_GetFeatures();
     else
@@ -1526,6 +1573,7 @@ int Xoodootimes16_GetFeatures()
 
 void Xoodootimes16_StaticInitialize()
 {
+    XKCP_EnsureProcessorCapabilities();
     if (XKCP_enableAVX512)
         Xoodootimes16_AVX512_StaticInitialize();
     else


### PR DESCRIPTION
# Runtime dispatch: detect CPU features automatically

## Motivation

The runtime-dispatch targets (`x86-64`, AArch64) currently behave differently on first use:

- **AArch64** lazily runs `XKCP_SetProcessorCapabilities()` from `KeccakP1600_StaticInitialize()`, so the SHA3-accelerated backend is selected even when the application never calls `XKCP_EnableAllCpuFeatures()`.
- **x86-64** leaves `XKCP_enableSSSE3/AVX2/AVX512` at 0 until the application explicitly opts in. A consumer that doesn't know about the (new) capability API — e.g. an existing application switching from a fixed-ISA `libXKCP.so` to the `x86-64` dispatch build as a drop-in replacement — silently runs the plain64 serial fallback everywhere. Because `KeccakP1600timesN_GetFeatures()` then reports no parallel features, ParallelHash, KangarooTwelve, Kravatte and Xoofff are also steered away from the parallel kernels.

The AArch64 layer has a smaller flavor of the same gap: `KeccakP1600_GetImplementation()` consults `XKCP_enableSHA3` before any `StaticInitialize()` has run the detection, so an early query reports the generic backend on SHA3-capable hardware.

## What this PR does

- Adds an identical `XKCP_EnsureProcessorCapabilities()` helper to both dispatch layers: a once-guard around `XKCP_SetProcessorCapabilities()`. It is called at the top of every dispatcher entry point that is consulted before any state exists — `*_GetImplementation()`, `*_GetFeatures()` and `*_StaticInitialize()` (24 sites in `x86-64-dispatch.c`, 3 in `aarch64-dispatch.c`). The AArch64 `StaticInitialize`'s existing inline once-guard is folded into the shared helper, so the two files now follow the same pattern.
- On GCC/Clang, additionally runs the detection from a `__attribute__((constructor))` at load time, while the process is still single-threaded. This means multithreaded applications normally never reach the lazy path at all; the lazy calls remain as a fallback for toolchains without constructor support, and for the (unsupported but conceivable) case of another constructor using XKCP before ours runs.
- Hot paths (permute, absorb, byte/lane management) are untouched and still read the enable flags directly.

## What does not change

- `XKCP_Disable*()`, `XKCP_EnableAllCpuFeatures()` and `XKCP_ProcessCpuFeatureCommandLineOption()` keep their semantics. The detection honors the `XKCP_*_requested_disabled` flags, so disabling a feature at startup (before instances are created) works exactly as before — verified with `UnitTests --disableAVX512`.
- `GetFeatures()` keeps returning 0 / `StaticInitialize()` keeps asserting for units whose ISA the CPU genuinely lacks; in fact `GetFeatures()` now answers truthfully on capable hardware instead of reporting "nothing" before an explicit enable call.

## Behavior change to be aware of

An x86-64 application that deliberately relied on the *old* default (all SIMD off unless `XKCP_EnableAllCpuFeatures()` is called) — for example to avoid AVX-512 frequency licensing effects — now needs to opt out explicitly by calling `XKCP_DisableSSSE3()`, `XKCP_DisableAVX2()` and/or `XKCP_DisableAVX512()` before first use. This matches the behavior the AArch64 dispatch layer already had. As before, capabilities should be configured once at startup: toggling them while hash instances are live is unsafe on x86-64 because the backend state layouts in the `KeccakP1600_state` union differ.

## Thread-safety note

The lazy fallback uses the same plain `static int` once-guard the AArch64 layer already used. With the load-time constructor, detection completes before `main()` on GCC/Clang, so concurrent first use does not race in practice. On toolchains without constructor support, a theoretical first-use race remains (the detection is idempotent; worst case is a transient serial-fallback answer on one thread). Closing it fully would take C11 atomics or the GCC/Clang `__atomic`/`__sync` builtins; given XKCP currently targets C99 and the window is small, this PR leaves the guard plain — it can be revisited if it ever matters in practice.

## Validation

On x86-64 (Ice Lake, AVX-512):

- Full `UnitTests --all` passes; FIPS202 ShortMsgKAT generation passes (run from `tests/TestVectors/`).
- A freshly loaded `x86-64/libXKCP.so` now reports "AVX512 optimized implementation" with no API call, and SnP/PlSnP self-tests pass for all eight dispatch units; previously it reported the generic 64-bit implementation until `XKCP_EnableAllCpuFeatures()` was called.
- `UnitTests --disableAVX512` correctly drops to the AVX2 implementations, `--disableAVX512 --disableAVX2` to SSSE3/plain64.
- A pre-built binary compiled against an older fixed-ISA `libXKCP.so` produces byte-identical KMAC128 output (NIST SP 800-185 sample vectors) against the patched dispatch library, confirming drop-in behavior.

On aarch64 (Apple M1 Pro)

- Full `UnitTests --all` passes; FIPS202 ShortMsgKAT generation passes (run from `tests/TestVectors/`).
- A freshly loaded `aarch64/libXKCP.so` now reports "ARMv8.4-A NEON SHA3 instructions implementation (x1, mlkem-native)" with no API call, and SnP/PlSnP self-tests pass for all eight dispatch units
- `UnitTests --disableSHA3` correctly drops to the SHA4 implementations
