### PR TITLE
Fix unaligned and aliasing-violating lane accesses in portable code

### DIFF
--- a/lib/LowLevel.build
+++ b/lib/LowLevel.build
@@ -106,6 +106,7 @@ The fragments below allow to select the desired implementation of the permutatio
 
     <fragment name="optimized">
         <h>lib/common/brg_endian.h</h>
+        <h>lib/common/load-store.h</h>
         <gcc>-fomit-frame-pointer</gcc>
         <gcc>-O2</gcc>
         <gcc>-g0</gcc>

--- a/lib/common/load-store.h
+++ b/lib/common/load-store.h
@@ -1,0 +1,53 @@
+/*
+The eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+Implementation by the XKCP contributors, hereby denoted as "the implementer".
+
+For more information, feedback or questions, please refer to the Keccak Team website:
+https://keccak.team/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#ifndef _load_store_h_
+#define _load_store_h_
+
+#include <stdint.h>
+#include <string.h>
+
+/*
+Read and write integer lanes through byte pointers, without requiring the
+pointer to be aligned and without violating strict aliasing. The memcpy()
+compiles to a single load or store on architectures that support misaligned
+accesses, and to a safe byte sequence on those that do not. The value uses
+the host byte order, exactly like a pointer cast would.
+*/
+
+static inline uint32_t XKCP_load32(const void *p)
+{
+    uint32_t v;
+    memcpy(&v, p, sizeof(v));
+    return v;
+}
+
+static inline uint64_t XKCP_load64(const void *p)
+{
+    uint64_t v;
+    memcpy(&v, p, sizeof(v));
+    return v;
+}
+
+static inline void XKCP_store32(void *p, uint32_t v)
+{
+    memcpy(p, &v, sizeof(v));
+}
+
+static inline void XKCP_store64(void *p, uint64_t v)
+{
+    memcpy(p, &v, sizeof(v));
+}
+
+#endif

--- a/lib/high/Keccak/KeccakOD.inc
+++ b/lib/high/Keccak/KeccakOD.inc
@@ -15,6 +15,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 */
 
 #include "align.h"
+#include "load-store.h"
 
 #define JOIN0(a, b)                     a ## b
 #define JOIN(a, b)                      JOIN0(a, b)
@@ -73,7 +74,7 @@ size_t OD_DuplexingFast( KeccakWidth1600_ODInstance *od, const uint8_t *idata, s
     od->o = r;
 
     if (SnP_GetFeatures() & SnP_Feature_OD)
-        return SnP_ODDuplexingFastInOut(&od->s, r/8, idata, len, odata, odataAdd, *(const uint64_t*)trailenc);
+        return SnP_ODDuplexingFastInOut(&od->s, r/8, idata, len, odata, odataAdd, XKCP_load64(trailenc));
 
     size_t  initialLen = len;
     do {
@@ -104,7 +105,7 @@ size_t OD_DuplexingFastOnlyOut( KeccakWidth1600_ODInstance *od, unsigned int E, 
     od->o = r;
 
     if (SnP_GetFeatures() & SnP_Feature_OD)
-        return SnP_ODDuplexingFastOut( &od->s, r/8, odata, len, odataAdd, *(const uint64_t*)trailenc );
+        return SnP_ODDuplexingFastOut( &od->s, r/8, odata, len, odataAdd, XKCP_load64(trailenc) );
 
     size_t  initialLen = len;
     do {
@@ -134,7 +135,7 @@ size_t OD_DuplexingFastOnlyIn( KeccakWidth1600_ODInstance *od, const uint8_t *id
     od->o = 0;
 
     if (SnP_GetFeatures() & SnP_Feature_OD)
-        return SnP_ODDuplexingFastIn( &od->s, r/8, idata, len, *(const uint64_t*)trailenc );
+        return SnP_ODDuplexingFastIn( &od->s, r/8, idata, len, XKCP_load64(trailenc) );
 
     size_t initialLen = len;
     do {

--- a/lib/high/Kravatte/Kravatte.c
+++ b/lib/high/Kravatte/Kravatte.c
@@ -20,6 +20,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include <string.h>
 #include <stdlib.h>
 #include "brg_endian.h"
+#include "load-store.h"
 #include "Kravatte.h"
 
 #ifdef XKCP_has_KeccakP1600times2
@@ -122,7 +123,7 @@ static void DUMP64( const unsigned char * pText, const unsigned char * pData, un
         KeccakP1600times##Parallellism##_StaticInitialize(); \
         mInitializePl(states, Parallellism); \
         do { \
-            Kravatte_Rollc( (uint64_t*)k, encbuf, Parallellism ); \
+            Kravatte_Rollc( k, encbuf, Parallellism ); \
             KeccakP1600times##Parallellism##_OverwriteLanesAll(&states, k, Kravatte_RollcOffset/8, 0); \
             i = 0; \
             do { \
@@ -149,7 +150,7 @@ static void DUMP64( const unsigned char * pText, const unsigned char * pData, un
         KeccakP1600times##Parallellism##_StaticInitialize(); \
         mInitializePl(states, Parallellism); \
         do { \
-            Kravatte_Rolle( (uint64_t*)kv->yAccu, encbuf, Parallellism ); \
+            Kravatte_Rolle( kv->yAccu, encbuf, Parallellism ); \
             KeccakP1600times##Parallellism##_OverwriteLanesAll(&states, kv->yAccu, Kravatte_RolleOffset/8, 0); \
             i = 0; \
             do { \
@@ -166,26 +167,27 @@ static void DUMP64( const unsigned char * pText, const unsigned char * pData, un
         } while ( outputByteLen >= Parallellism * SnP_widthInBytes ); \
     }
 
-static void Kravatte_Rollc( uint64_t *x, unsigned char *encbuf, unsigned int parallellism )
+static void Kravatte_Rollc( unsigned char *xbuf, unsigned char *encbuf, unsigned int parallellism )
 {
-    uint64_t    x0 = x[20];
-    uint64_t    x1 = x[21];
-    uint64_t    x2 = x[22];
-    uint64_t    x3 = x[23];
-    uint64_t    x4 = x[24];
+    uint64_t    x0 = XKCP_load64(xbuf+20*8);
+    uint64_t    x1 = XKCP_load64(xbuf+21*8);
+    uint64_t    x2 = XKCP_load64(xbuf+22*8);
+    uint64_t    x3 = XKCP_load64(xbuf+23*8);
+    uint64_t    x4 = XKCP_load64(xbuf+24*8);
     uint64_t    t;
     #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    uint64_t    *pEnc = (uint64_t*)encbuf;
+    unsigned char *pEnc = encbuf;
     #endif
 
     do {
         #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-        *(pEnc++) = x0;
-        *(pEnc++) = x1;
-        *(pEnc++) = x2;
-        *(pEnc++) = x3;
-        *(pEnc++) = x4;
-        DUMP("Rollc", pEnc - Kravatte_RollcSizeInBytes/8, Kravatte_RollcSizeInBytes);
+        XKCP_store64(pEnc+0*8, x0);
+        XKCP_store64(pEnc+1*8, x1);
+        XKCP_store64(pEnc+2*8, x2);
+        XKCP_store64(pEnc+3*8, x3);
+        XKCP_store64(pEnc+4*8, x4);
+        pEnc += 5*8;
+        DUMP("Rollc", pEnc - Kravatte_RollcSizeInBytes, Kravatte_RollcSizeInBytes);
         #else
         #error todo
         #endif
@@ -198,45 +200,46 @@ static void Kravatte_Rollc( uint64_t *x, unsigned char *encbuf, unsigned int par
         x4 = ROL64(t, 7) ^ x0 ^ (x0 >> 3);
     } while(--parallellism != 0); 
 
-    x[20] = x0;
-    x[21] = x1;
-    x[22] = x2;
-    x[23] = x3;
-    x[24] = x4;
-    DUMP("Rollc state", pEnc - Kravatte_RollcSizeInBytes/8, Kravatte_RollcSizeInBytes);
+    XKCP_store64(xbuf+20*8, x0);
+    XKCP_store64(xbuf+21*8, x1);
+    XKCP_store64(xbuf+22*8, x2);
+    XKCP_store64(xbuf+23*8, x3);
+    XKCP_store64(xbuf+24*8, x4);
+    DUMP("Rollc state", pEnc - Kravatte_RollcSizeInBytes, Kravatte_RollcSizeInBytes);
 
 }
 
-static void Kravatte_Rolle( uint64_t *x, unsigned char *encbuf, unsigned int parallellism )
+static void Kravatte_Rolle( unsigned char *xbuf, unsigned char *encbuf, unsigned int parallellism )
 {
-    uint64_t    x0 = x[15];
-    uint64_t    x1 = x[16];
-    uint64_t    x2 = x[17];
-    uint64_t    x3 = x[18];
-    uint64_t    x4 = x[19];
-    uint64_t    x5 = x[20];
-    uint64_t    x6 = x[21];
-    uint64_t    x7 = x[22];
-    uint64_t    x8 = x[23];
-    uint64_t    x9 = x[24];
+    uint64_t    x0 = XKCP_load64(xbuf+15*8);
+    uint64_t    x1 = XKCP_load64(xbuf+16*8);
+    uint64_t    x2 = XKCP_load64(xbuf+17*8);
+    uint64_t    x3 = XKCP_load64(xbuf+18*8);
+    uint64_t    x4 = XKCP_load64(xbuf+19*8);
+    uint64_t    x5 = XKCP_load64(xbuf+20*8);
+    uint64_t    x6 = XKCP_load64(xbuf+21*8);
+    uint64_t    x7 = XKCP_load64(xbuf+22*8);
+    uint64_t    x8 = XKCP_load64(xbuf+23*8);
+    uint64_t    x9 = XKCP_load64(xbuf+24*8);
     uint64_t    t;
     #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    uint64_t    *pEnc = (uint64_t*)encbuf;
+    unsigned char *pEnc = encbuf;
     #endif
 
     do {
         #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-        *(pEnc++) = x0;
-        *(pEnc++) = x1;
-        *(pEnc++) = x2;
-        *(pEnc++) = x3;
-        *(pEnc++) = x4;
-        *(pEnc++) = x5;
-        *(pEnc++) = x6;
-        *(pEnc++) = x7;
-        *(pEnc++) = x8;
-        *(pEnc++) = x9;
-        DUMP("Rolle", pEnc - Kravatte_RolleSizeInBytes/8, Kravatte_RolleSizeInBytes);
+        XKCP_store64(pEnc+0*8, x0);
+        XKCP_store64(pEnc+1*8, x1);
+        XKCP_store64(pEnc+2*8, x2);
+        XKCP_store64(pEnc+3*8, x3);
+        XKCP_store64(pEnc+4*8, x4);
+        XKCP_store64(pEnc+5*8, x5);
+        XKCP_store64(pEnc+6*8, x6);
+        XKCP_store64(pEnc+7*8, x7);
+        XKCP_store64(pEnc+8*8, x8);
+        XKCP_store64(pEnc+9*8, x9);
+        pEnc += 10*8;
+        DUMP("Rolle", pEnc - Kravatte_RolleSizeInBytes, Kravatte_RolleSizeInBytes);
         #else
         #error todo
         #endif
@@ -254,16 +257,16 @@ static void Kravatte_Rolle( uint64_t *x, unsigned char *encbuf, unsigned int par
         x9 = ROL64(t, 7) ^ ROL64(x0, 18) ^ (x1 & (x0 >> 1));
     } while(--parallellism != 0); 
 
-    x[15] = x0;
-    x[16] = x1;
-    x[17] = x2;
-    x[18] = x3;
-    x[19] = x4;
-    x[20] = x5;
-    x[21] = x6;
-    x[22] = x7;
-    x[23] = x8;
-    x[24] = x9;
+    XKCP_store64(xbuf+15*8, x0);
+    XKCP_store64(xbuf+16*8, x1);
+    XKCP_store64(xbuf+17*8, x2);
+    XKCP_store64(xbuf+18*8, x3);
+    XKCP_store64(xbuf+19*8, x4);
+    XKCP_store64(xbuf+20*8, x5);
+    XKCP_store64(xbuf+21*8, x6);
+    XKCP_store64(xbuf+22*8, x7);
+    XKCP_store64(xbuf+23*8, x8);
+    XKCP_store64(xbuf+24*8, x9);
     DUMP("Rolle state", pEnc - Kravatte_RolleSizeInBytes/8, Kravatte_RolleSizeInBytes);
 
 }
@@ -305,7 +308,7 @@ static const unsigned char * Kra_Compress( unsigned char *k, unsigned char *x, c
         mInitialize(&state);
         do {
             KeccakP1600_OverwriteBytes(&state, k, 0, SnP_widthInBytes);
-            Kravatte_Rollc((uint64_t*)k, encbuf, 1);
+            Kravatte_Rollc( k, encbuf, 1);
             KeccakP1600_AddBytes(&state, message, 0, SnP_widthInBytes);
             DUMP("msg p1", message, SnP_widthInBytes);
             KeccakP1600_Permute_Nrounds(&state, 6);
@@ -325,7 +328,7 @@ static const unsigned char * Kra_Compress( unsigned char *k, unsigned char *x, c
         KeccakP1600_StaticInitialize();
         mInitialize(&state);
         KeccakP1600_OverwriteBytes(&state, k, 0, SnP_widthInBytes); /* write k */
-        Kravatte_Rollc((uint64_t*)k, encbuf, 1);
+        Kravatte_Rollc( k, encbuf, 1);
         KeccakP1600_AddBytes(&state, message, 0, (unsigned int)messageByteLen); /* add message */
         DUMP("msg pL", state, SnP_widthInBytes);
         message += messageByteLen;
@@ -337,7 +340,7 @@ static const unsigned char * Kra_Compress( unsigned char *k, unsigned char *x, c
         KeccakP1600_Permute_Nrounds(&state, 6);
         KeccakP1600_ExtractAndAddBytes(&state, x, x, 0, SnP_widthInBytes);
         DUMP("xAc pL", x, SnP_widthInBytes);
-        Kravatte_Rollc((uint64_t*)k, encbuf, 1);
+        Kravatte_Rollc( k, encbuf, 1);
         *messageBitLen = 0;
     }
     return message;
@@ -504,7 +507,7 @@ int Vatte(Kravatte_Instance *kv, BitSequence *output, BitLength outputBitLen, in
         do {
             len = (unsigned int)MyMin(outputByteLen, SnP_widthInBytes);
             KeccakP1600_OverwriteBytes(&state, kv->yAccu, 0, SnP_widthInBytes);
-            Kravatte_Rolle((uint64_t*)kv->yAccu, encbuf, 1);
+            Kravatte_Rolle( kv->yAccu, encbuf, 1);
             KeccakP1600_Permute_Nrounds(&state, 6);
             KeccakP1600_ExtractAndAddBytes(&state, kv->kRoll, output, 0, len);
             DUMP("out 1", output, len);

--- a/lib/high/Kravatte/KravatteModes.c
+++ b/lib/high/Kravatte/KravatteModes.c
@@ -16,6 +16,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #include <string.h>
 #include "brg_endian.h"
+#include "load-store.h"
 #include "Kravatte.h"
 #include "KravatteModes.h"
 
@@ -53,23 +54,21 @@ static void memxoris(BitSequence *target, const BitSequence *source, BitLength b
 {
     size_t  byteLen = bitLen / 8;
 
-    #if !defined(NO_MISALIGNED_ACCESSES)
     while ( byteLen >= 32 ) {
-        *((uint64_t*)(target+0)) ^= *((uint64_t*)(source+0));
-        *((uint64_t*)(target+8)) ^= *((uint64_t*)(source+8));
-        *((uint64_t*)(target+16)) ^= *((uint64_t*)(source+16));
-        *((uint64_t*)(target+24)) ^= *((uint64_t*)(source+24));
+        XKCP_store64(target+0, XKCP_load64(target+0) ^ XKCP_load64(source+0));
+        XKCP_store64(target+8, XKCP_load64(target+8) ^ XKCP_load64(source+8));
+        XKCP_store64(target+16, XKCP_load64(target+16) ^ XKCP_load64(source+16));
+        XKCP_store64(target+24, XKCP_load64(target+24) ^ XKCP_load64(source+24));
         source += 32;
         target += 32;
         byteLen -= 32;
     }
     while ( byteLen >= 8 ) {
-        *((uint64_t*)target) ^= *((uint64_t*)source);
+        XKCP_store64(target, XKCP_load64(target) ^ XKCP_load64(source));
         source += 8;
         target += 8;
         byteLen -= 8;
     }
-    #endif
 
     while ( byteLen-- != 0 )
     {

--- a/lib/high/Xoofff/Xoofff.c
+++ b/lib/high/Xoofff/Xoofff.c
@@ -21,6 +21,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include <stdio.h>
 #include <stdlib.h>
 #include "brg_endian.h"
+#include "load-store.h"
 #include "Xoofff.h"
 #include "Xoodoo.h"
 #ifdef XKCP_has_Xoodootimes16
@@ -140,7 +141,7 @@ static void DumpBuf( const unsigned char * pText, const unsigned char * pData, u
         Xoodootimes##Parallellism##_StaticInitialize(); \
         mInitializePl(states, Parallellism); \
         do { \
-            Xoofff_Rollc( (uint32_t*)k, encbuf, Parallellism ); \
+            Xoofff_Rollc( k, encbuf, Parallellism ); \
             i = 0; \
             do { \
                 Xoodootimes##Parallellism##_OverwriteBytes(&states, i, encbuf + i * Xoofff_RollSizeInBytes, Xoofff_RollOffset, Xoofff_RollSizeInBytes); \
@@ -166,7 +167,7 @@ static void DumpBuf( const unsigned char * pText, const unsigned char * pData, u
         Xoodootimes##Parallellism##_StaticInitialize(); \
         mInitializePl(states, Parallellism); \
         do { \
-            Xoofff_Rolle( (uint32_t*)xp->yAccu, encbuf, Parallellism ); \
+            Xoofff_Rolle( xp->yAccu, encbuf, Parallellism ); \
             i = 0; \
             do { \
                 Xoodootimes##Parallellism##_OverwriteBytes(&states, i, encbuf + i * Xoofff_RollSizeInBytes, Xoofff_RollOffset, Xoofff_RollSizeInBytes); \
@@ -182,28 +183,32 @@ static void DumpBuf( const unsigned char * pText, const unsigned char * pData, u
         } while ( outputByteLen >= Parallellism * SnP_widthInBytes ); \
     }
 
-static void Xoofff_Rollc( uint32_t *a, unsigned char *encbuf, unsigned int parallellism )
+static void Xoofff_Rollc( unsigned char *abuf, unsigned char *encbuf, unsigned int parallellism )
 {
+    uint32_t    a[3*NCOLUMS];
     uint32_t    b[NCOLUMS];
+
+    memcpy(a, abuf, sizeof(a));
     #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    uint32_t    *pEnc = (uint32_t*)encbuf;
+    unsigned char *pEnc = encbuf;
     #endif
 
     do {
         #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-        *(pEnc++) = a[0];
-        *(pEnc++) = a[1];
-        *(pEnc++) = a[2];
-        *(pEnc++) = a[3];
-        *(pEnc++) = a[4];
-        *(pEnc++) = a[5];
-        *(pEnc++) = a[6];
-        *(pEnc++) = a[7];
-        *(pEnc++) = a[8];
-        *(pEnc++) = a[9];
-        *(pEnc++) = a[10];
-        *(pEnc++) = a[11];
-        DUMP("Roll-c", pEnc - Xoofff_RollSizeInBytes/4, Xoofff_RollSizeInBytes);
+        XKCP_store32(pEnc+0*4, a[0]);
+        XKCP_store32(pEnc+1*4, a[1]);
+        XKCP_store32(pEnc+2*4, a[2]);
+        XKCP_store32(pEnc+3*4, a[3]);
+        XKCP_store32(pEnc+4*4, a[4]);
+        XKCP_store32(pEnc+5*4, a[5]);
+        XKCP_store32(pEnc+6*4, a[6]);
+        XKCP_store32(pEnc+7*4, a[7]);
+        XKCP_store32(pEnc+8*4, a[8]);
+        XKCP_store32(pEnc+9*4, a[9]);
+        XKCP_store32(pEnc+10*4, a[10]);
+        XKCP_store32(pEnc+11*4, a[11]);
+        pEnc += 12*4;
+        DUMP("Roll-c", pEnc - Xoofff_RollSizeInBytes, Xoofff_RollSizeInBytes);
         #else
         #error todo
         #endif
@@ -229,31 +234,36 @@ static void Xoofff_Rollc( uint32_t *a, unsigned char *encbuf, unsigned int paral
         a[8+2] = b[2];
         a[8+3] = b[3];
     } while(--parallellism != 0);
+    memcpy(abuf, a, sizeof(a));
     DUMP("Roll-c next", a, Xoofff_RollSizeInBytes);
 }
 
-static void Xoofff_Rolle( uint32_t *a, unsigned char *encbuf, unsigned int parallellism )
+static void Xoofff_Rolle( unsigned char *abuf, unsigned char *encbuf, unsigned int parallellism )
 {
+    uint32_t    a[3*NCOLUMS];
     uint32_t    b[NCOLUMS];
+
+    memcpy(a, abuf, sizeof(a));
     #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    uint32_t    *pEnc = (uint32_t*)encbuf;
+    unsigned char *pEnc = encbuf;
     #endif
 
     do {
         #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-        *(pEnc++) = a[0];
-        *(pEnc++) = a[1];
-        *(pEnc++) = a[2];
-        *(pEnc++) = a[3];
-        *(pEnc++) = a[4];
-        *(pEnc++) = a[5];
-        *(pEnc++) = a[6];
-        *(pEnc++) = a[7];
-        *(pEnc++) = a[8];
-        *(pEnc++) = a[9];
-        *(pEnc++) = a[10];
-        *(pEnc++) = a[11];
-        DUMP("Roll-e", pEnc - Xoofff_RollSizeInBytes/4, Xoofff_RollSizeInBytes);
+        XKCP_store32(pEnc+0*4, a[0]);
+        XKCP_store32(pEnc+1*4, a[1]);
+        XKCP_store32(pEnc+2*4, a[2]);
+        XKCP_store32(pEnc+3*4, a[3]);
+        XKCP_store32(pEnc+4*4, a[4]);
+        XKCP_store32(pEnc+5*4, a[5]);
+        XKCP_store32(pEnc+6*4, a[6]);
+        XKCP_store32(pEnc+7*4, a[7]);
+        XKCP_store32(pEnc+8*4, a[8]);
+        XKCP_store32(pEnc+9*4, a[9]);
+        XKCP_store32(pEnc+10*4, a[10]);
+        XKCP_store32(pEnc+11*4, a[11]);
+        pEnc += 12*4;
+        DUMP("Roll-e", pEnc - Xoofff_RollSizeInBytes, Xoofff_RollSizeInBytes);
         #else
         #error todo
         #endif
@@ -279,6 +289,7 @@ static void Xoofff_Rolle( uint32_t *a, unsigned char *encbuf, unsigned int paral
         a[8+2] = b[2];
         a[8+3] = b[3];
     } while(--parallellism != 0);
+    memcpy(abuf, a, sizeof(a));
     DUMP("Roll-e next", a, Xoofff_RollSizeInBytes);
 }
 
@@ -289,23 +300,21 @@ void Xoofff_AddIs_dispatch(unsigned char *output, const unsigned char *input, si
     else {
         size_t  byteLen = bitLen / 8;
 
-        #if !defined(NO_MISALIGNED_ACCESSES)
         while ( byteLen >= 32 ) {
-            *((uint64_t*)(output+0)) ^= *((const uint64_t*)(input+0));
-            *((uint64_t*)(output+8)) ^= *((const uint64_t*)(input+8));
-            *((uint64_t*)(output+16)) ^= *((const uint64_t*)(input+16));
-            *((uint64_t*)(output+24)) ^= *((const uint64_t*)(input+24));
+            XKCP_store64(output+0, XKCP_load64(output+0) ^ XKCP_load64(input+0));
+            XKCP_store64(output+8, XKCP_load64(output+8) ^ XKCP_load64(input+8));
+            XKCP_store64(output+16, XKCP_load64(output+16) ^ XKCP_load64(input+16));
+            XKCP_store64(output+24, XKCP_load64(output+24) ^ XKCP_load64(input+24));
             input += 32;
             output += 32;
             byteLen -= 32;
         }
         while ( byteLen >= 8 ) {
-            *((uint64_t*)output) ^= *((const uint64_t*)input);
+            XKCP_store64(output, XKCP_load64(output) ^ XKCP_load64(input));
             input += 8;
             output += 8;
             byteLen -= 8;
         }
-        #endif
 
         while ( byteLen-- != 0 )
         {
@@ -337,7 +346,7 @@ size_t Xoofff_CompressFastLoop_dispatch(unsigned char *k, unsigned char *x, cons
         mInitialize(state);
         do {
             Xoodoo_OverwriteBytes(&state, k, 0, SnP_widthInBytes);
-            Xoofff_Rollc((uint32_t*)k, encbuf, 1);
+            Xoofff_Rollc( k, encbuf, 1);
             Xoodoo_AddBytes(&state, input, 0, SnP_widthInBytes);
             DUMP("msg p1", input, SnP_widthInBytes);
             Xoodoo_Permute_6rounds(&state);
@@ -368,7 +377,7 @@ size_t Xoofff_ExpandFastLoop_dispatch(unsigned char *yAccu, const unsigned char 
         mInitialize(state);
         do {
             Xoodoo_OverwriteBytes(&state, yAccu, 0, SnP_widthInBytes);
-            Xoofff_Rolle((uint32_t*)yAccu, encbuf, 1);
+            Xoofff_Rolle( yAccu, encbuf, 1);
             Xoodoo_Permute_6rounds(&state);
             Xoodoo_ExtractAndAddBytes(&state, kRoll, output, 0, SnP_widthInBytes);
             DUMP("out 1", output, SnP_widthInBytes);
@@ -433,7 +442,7 @@ static const unsigned char * Xoodoo_CompressBlocks( unsigned char *k, unsigned c
         Xoodoo_StaticInitialize();
         mInitialize(state);
         Xoodoo_OverwriteBytes(&state, k, 0, SnP_widthInBytes); /* write k */
-        Xoofff_Rollc((uint32_t*)k, encbuf, 1);
+        Xoofff_Rollc( k, encbuf, 1);
         Xoodoo_AddBytes(&state, message, 0, (unsigned int)messageByteLen); /* add message */
         DUMP("msg pL", &state, SnP_widthInBytes);
         message += messageByteLen;
@@ -445,7 +454,7 @@ static const unsigned char * Xoodoo_CompressBlocks( unsigned char *k, unsigned c
         Xoodoo_Permute_6rounds(&state);
         Xoodoo_ExtractAndAddBytes(&state, x, x, 0, SnP_widthInBytes);
         DUMP("xAc pL", x, SnP_widthInBytes);
-        Xoofff_Rollc((uint32_t*)k, encbuf, 1);
+        Xoofff_Rollc( k, encbuf, 1);
         *messageBitLen = 0;
     }
     return message;
@@ -626,7 +635,7 @@ int Xoofff_Expand(Xoofff_Instance *xp, BitSequence *output, BitLength outputBitL
         Xoodoo_StaticInitialize();
         mInitialize(state);
         Xoodoo_OverwriteBytes(&state, xp->yAccu, 0, SnP_widthInBytes);
-        Xoofff_Rolle((uint32_t*)xp->yAccu, encbuf, 1);
+        Xoofff_Rolle( xp->yAccu, encbuf, 1);
         Xoodoo_Permute_6rounds(&state);
         Xoodoo_ExtractAndAddBytes(&state, xp->kRoll, output, 0, (unsigned int)outputByteLen);
         DUMP("out 1", output, outputByteLen);

--- a/lib/low/KeccakP-1600/common/KeccakP-1600-64.macros
+++ b/lib/low/KeccakP-1600/common/KeccakP-1600-64.macros
@@ -539,53 +539,53 @@ http://creativecommons.org/publicdomain/zero/1.0/
     X##so = Y##so; \
     X##su = Y##su; \
 
-#if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-#define HTOLE64(x) (x)
-#else
 /*
- * Big Endian platforms macro to swap data.
- *
- * NOTE: we cannot directly use the 64-bit input
- * of the following macro because of possible alignment
- * constraints (on some platforms such as Sparc or MIPS,
- * dereferencing an uint64_t on a buffer not aligned on the
- * word size will induce a 'bus error'). Instead, we read and
- * swap the data byte per byte.
+ * Read the little-endian lane number i from the input byte stream,
+ * without requiring the pointer to be aligned. On little-endian
+ * platforms, XKCP_load64() lets the compiler emit a single (possibly
+ * misaligned) load where the architecture supports it, and a safe byte
+ * sequence elsewhere (on some platforms such as Sparc or MIPS,
+ * dereferencing an uint64_t on a buffer not aligned on the word size
+ * will induce a 'bus error'). On big-endian platforms, the lane is read
+ * and swapped byte per byte.
  */
-#define HTOLE64(x)                                         \
-        (  ((uint64_t) (((uint8_t*)&(x))[ 7]) << 56 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 6]) << 48 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 5]) << 40 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 4]) << 32 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 3]) << 24 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 2]) << 16 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 1]) <<  8 )                \
-        |  ((uint64_t) (((uint8_t*)&(x))[ 0])))
+#if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
+#define loadInputLane(input, i) XKCP_load64((input)+8*(i))
+#else
+#define loadInputLane(input, i)                                      \
+        (  ((uint64_t) ((input)[8*(i)+7]) << 56 )                    \
+        |  ((uint64_t) ((input)[8*(i)+6]) << 48 )                    \
+        |  ((uint64_t) ((input)[8*(i)+5]) << 40 )                    \
+        |  ((uint64_t) ((input)[8*(i)+4]) << 32 )                    \
+        |  ((uint64_t) ((input)[8*(i)+3]) << 24 )                    \
+        |  ((uint64_t) ((input)[8*(i)+2]) << 16 )                    \
+        |  ((uint64_t) ((input)[8*(i)+1]) <<  8 )                    \
+        |  ((uint64_t) ((input)[8*(i)+0])))
 #endif
 
 #define addInput(X, input, laneCount) \
     if (laneCount == 21) { \
-        X##ba ^= HTOLE64(input[ 0]); \
-        X##be ^= HTOLE64(input[ 1]); \
-        X##bi ^= HTOLE64(input[ 2]); \
-        X##bo ^= HTOLE64(input[ 3]); \
-        X##bu ^= HTOLE64(input[ 4]); \
-        X##ga ^= HTOLE64(input[ 5]); \
-        X##ge ^= HTOLE64(input[ 6]); \
-        X##gi ^= HTOLE64(input[ 7]); \
-        X##go ^= HTOLE64(input[ 8]); \
-        X##gu ^= HTOLE64(input[ 9]); \
-        X##ka ^= HTOLE64(input[10]); \
-        X##ke ^= HTOLE64(input[11]); \
-        X##ki ^= HTOLE64(input[12]); \
-        X##ko ^= HTOLE64(input[13]); \
-        X##ku ^= HTOLE64(input[14]); \
-        X##ma ^= HTOLE64(input[15]); \
-        X##me ^= HTOLE64(input[16]); \
-        X##mi ^= HTOLE64(input[17]); \
-        X##mo ^= HTOLE64(input[18]); \
-        X##mu ^= HTOLE64(input[19]); \
-        X##sa ^= HTOLE64(input[20]); \
+        X##ba ^= loadInputLane(input, 0); \
+        X##be ^= loadInputLane(input, 1); \
+        X##bi ^= loadInputLane(input, 2); \
+        X##bo ^= loadInputLane(input, 3); \
+        X##bu ^= loadInputLane(input, 4); \
+        X##ga ^= loadInputLane(input, 5); \
+        X##ge ^= loadInputLane(input, 6); \
+        X##gi ^= loadInputLane(input, 7); \
+        X##go ^= loadInputLane(input, 8); \
+        X##gu ^= loadInputLane(input, 9); \
+        X##ka ^= loadInputLane(input, 10); \
+        X##ke ^= loadInputLane(input, 11); \
+        X##ki ^= loadInputLane(input, 12); \
+        X##ko ^= loadInputLane(input, 13); \
+        X##ku ^= loadInputLane(input, 14); \
+        X##ma ^= loadInputLane(input, 15); \
+        X##me ^= loadInputLane(input, 16); \
+        X##mi ^= loadInputLane(input, 17); \
+        X##mo ^= loadInputLane(input, 18); \
+        X##mu ^= loadInputLane(input, 19); \
+        X##sa ^= loadInputLane(input, 20); \
     } \
     else if (laneCount < 16) { \
         if (laneCount < 8) { \
@@ -594,165 +594,165 @@ http://creativecommons.org/publicdomain/zero/1.0/
                     if (laneCount < 1) { \
                     } \
                     else { \
-                        X##ba ^= HTOLE64(input[ 0]); \
+                        X##ba ^= loadInputLane(input, 0); \
                     } \
                 } \
                 else { \
-                    X##ba ^= HTOLE64(input[ 0]); \
-                    X##be ^= HTOLE64(input[ 1]); \
+                    X##ba ^= loadInputLane(input, 0); \
+                    X##be ^= loadInputLane(input, 1); \
                     if (laneCount < 3) { \
                     } \
                     else { \
-                        X##bi ^= HTOLE64(input[ 2]); \
+                        X##bi ^= loadInputLane(input, 2); \
                     } \
                 } \
             } \
             else { \
-                X##ba ^= HTOLE64(input[ 0]); \
-                X##be ^= HTOLE64(input[ 1]); \
-                X##bi ^= HTOLE64(input[ 2]); \
-                X##bo ^= HTOLE64(input[ 3]); \
+                X##ba ^= loadInputLane(input, 0); \
+                X##be ^= loadInputLane(input, 1); \
+                X##bi ^= loadInputLane(input, 2); \
+                X##bo ^= loadInputLane(input, 3); \
                 if (laneCount < 6) { \
                     if (laneCount < 5) { \
                     } \
                     else { \
-                        X##bu ^= HTOLE64(input[ 4]); \
+                        X##bu ^= loadInputLane(input, 4); \
                     } \
                 } \
                 else { \
-                    X##bu ^= HTOLE64(input[ 4]); \
-                    X##ga ^= HTOLE64(input[ 5]); \
+                    X##bu ^= loadInputLane(input, 4); \
+                    X##ga ^= loadInputLane(input, 5); \
                     if (laneCount < 7) { \
                     } \
                     else { \
-                        X##ge ^= HTOLE64(input[ 6]); \
+                        X##ge ^= loadInputLane(input, 6); \
                     } \
                 } \
             } \
         } \
         else { \
-            X##ba ^= HTOLE64(input[ 0]); \
-            X##be ^= HTOLE64(input[ 1]); \
-            X##bi ^= HTOLE64(input[ 2]); \
-            X##bo ^= HTOLE64(input[ 3]); \
-            X##bu ^= HTOLE64(input[ 4]); \
-            X##ga ^= HTOLE64(input[ 5]); \
-            X##ge ^= HTOLE64(input[ 6]); \
-            X##gi ^= HTOLE64(input[ 7]); \
+            X##ba ^= loadInputLane(input, 0); \
+            X##be ^= loadInputLane(input, 1); \
+            X##bi ^= loadInputLane(input, 2); \
+            X##bo ^= loadInputLane(input, 3); \
+            X##bu ^= loadInputLane(input, 4); \
+            X##ga ^= loadInputLane(input, 5); \
+            X##ge ^= loadInputLane(input, 6); \
+            X##gi ^= loadInputLane(input, 7); \
             if (laneCount < 12) { \
                 if (laneCount < 10) { \
                     if (laneCount < 9) { \
                     } \
                     else { \
-                        X##go ^= HTOLE64(input[ 8]); \
+                        X##go ^= loadInputLane(input, 8); \
                     } \
                 } \
                 else { \
-                    X##go ^= HTOLE64(input[ 8]); \
-                    X##gu ^= HTOLE64(input[ 9]); \
+                    X##go ^= loadInputLane(input, 8); \
+                    X##gu ^= loadInputLane(input, 9); \
                     if (laneCount < 11) { \
                     } \
                     else { \
-                        X##ka ^= HTOLE64(input[10]); \
+                        X##ka ^= loadInputLane(input, 10); \
                     } \
                 } \
             } \
             else { \
-                X##go ^= HTOLE64(input[ 8]); \
-                X##gu ^= HTOLE64(input[ 9]); \
-                X##ka ^= HTOLE64(input[10]); \
-                X##ke ^= HTOLE64(input[11]); \
+                X##go ^= loadInputLane(input, 8); \
+                X##gu ^= loadInputLane(input, 9); \
+                X##ka ^= loadInputLane(input, 10); \
+                X##ke ^= loadInputLane(input, 11); \
                 if (laneCount < 14) { \
                     if (laneCount < 13) { \
                     } \
                     else { \
-                        X##ki ^= HTOLE64(input[12]); \
+                        X##ki ^= loadInputLane(input, 12); \
                     } \
                 } \
                 else { \
-                    X##ki ^= HTOLE64(input[12]); \
-                    X##ko ^= HTOLE64(input[13]); \
+                    X##ki ^= loadInputLane(input, 12); \
+                    X##ko ^= loadInputLane(input, 13); \
                     if (laneCount < 15) { \
                     } \
                     else { \
-                        X##ku ^= HTOLE64(input[14]); \
+                        X##ku ^= loadInputLane(input, 14); \
                     } \
                 } \
             } \
         } \
     } \
     else { \
-        X##ba ^= HTOLE64(input[ 0]); \
-        X##be ^= HTOLE64(input[ 1]); \
-        X##bi ^= HTOLE64(input[ 2]); \
-        X##bo ^= HTOLE64(input[ 3]); \
-        X##bu ^= HTOLE64(input[ 4]); \
-        X##ga ^= HTOLE64(input[ 5]); \
-        X##ge ^= HTOLE64(input[ 6]); \
-        X##gi ^= HTOLE64(input[ 7]); \
-        X##go ^= HTOLE64(input[ 8]); \
-        X##gu ^= HTOLE64(input[ 9]); \
-        X##ka ^= HTOLE64(input[10]); \
-        X##ke ^= HTOLE64(input[11]); \
-        X##ki ^= HTOLE64(input[12]); \
-        X##ko ^= HTOLE64(input[13]); \
-        X##ku ^= HTOLE64(input[14]); \
-        X##ma ^= HTOLE64(input[15]); \
+        X##ba ^= loadInputLane(input, 0); \
+        X##be ^= loadInputLane(input, 1); \
+        X##bi ^= loadInputLane(input, 2); \
+        X##bo ^= loadInputLane(input, 3); \
+        X##bu ^= loadInputLane(input, 4); \
+        X##ga ^= loadInputLane(input, 5); \
+        X##ge ^= loadInputLane(input, 6); \
+        X##gi ^= loadInputLane(input, 7); \
+        X##go ^= loadInputLane(input, 8); \
+        X##gu ^= loadInputLane(input, 9); \
+        X##ka ^= loadInputLane(input, 10); \
+        X##ke ^= loadInputLane(input, 11); \
+        X##ki ^= loadInputLane(input, 12); \
+        X##ko ^= loadInputLane(input, 13); \
+        X##ku ^= loadInputLane(input, 14); \
+        X##ma ^= loadInputLane(input, 15); \
         if (laneCount < 24) { \
             if (laneCount < 20) { \
                 if (laneCount < 18) { \
                     if (laneCount < 17) { \
                     } \
                     else { \
-                        X##me ^= HTOLE64(input[16]); \
+                        X##me ^= loadInputLane(input, 16); \
                     } \
                 } \
                 else { \
-                    X##me ^= HTOLE64(input[16]); \
-                    X##mi ^= HTOLE64(input[17]); \
+                    X##me ^= loadInputLane(input, 16); \
+                    X##mi ^= loadInputLane(input, 17); \
                     if (laneCount < 19) { \
                     } \
                     else { \
-                        X##mo ^= HTOLE64(input[18]); \
+                        X##mo ^= loadInputLane(input, 18); \
                     } \
                 } \
             } \
             else { \
-                X##me ^= HTOLE64(input[16]); \
-                X##mi ^= HTOLE64(input[17]); \
-                X##mo ^= HTOLE64(input[18]); \
-                X##mu ^= HTOLE64(input[19]); \
+                X##me ^= loadInputLane(input, 16); \
+                X##mi ^= loadInputLane(input, 17); \
+                X##mo ^= loadInputLane(input, 18); \
+                X##mu ^= loadInputLane(input, 19); \
                 if (laneCount < 22) { \
                     if (laneCount < 21) { \
                     } \
                     else { \
-                        X##sa ^= HTOLE64(input[20]); \
+                        X##sa ^= loadInputLane(input, 20); \
                     } \
                 } \
                 else { \
-                    X##sa ^= HTOLE64(input[20]); \
-                    X##se ^= HTOLE64(input[21]); \
+                    X##sa ^= loadInputLane(input, 20); \
+                    X##se ^= loadInputLane(input, 21); \
                     if (laneCount < 23) { \
                     } \
                     else { \
-                        X##si ^= HTOLE64(input[22]); \
+                        X##si ^= loadInputLane(input, 22); \
                     } \
                 } \
             } \
         } \
         else { \
-            X##me ^= HTOLE64(input[16]); \
-            X##mi ^= HTOLE64(input[17]); \
-            X##mo ^= HTOLE64(input[18]); \
-            X##mu ^= HTOLE64(input[19]); \
-            X##sa ^= HTOLE64(input[20]); \
-            X##se ^= HTOLE64(input[21]); \
-            X##si ^= HTOLE64(input[22]); \
-            X##so ^= HTOLE64(input[23]); \
+            X##me ^= loadInputLane(input, 16); \
+            X##mi ^= loadInputLane(input, 17); \
+            X##mo ^= loadInputLane(input, 18); \
+            X##mu ^= loadInputLane(input, 19); \
+            X##sa ^= loadInputLane(input, 20); \
+            X##se ^= loadInputLane(input, 21); \
+            X##si ^= loadInputLane(input, 22); \
+            X##so ^= loadInputLane(input, 23); \
             if (laneCount < 25) { \
             } \
             else { \
-                X##su ^= HTOLE64(input[24]); \
+                X##su ^= loadInputLane(input, 24); \
             } \
         } \
     }

--- a/lib/low/KeccakP-1600/compact/KeccakP-1600-compact64.c
+++ b/lib/low/KeccakP-1600/compact/KeccakP-1600-compact64.c
@@ -26,6 +26,7 @@ Please refer to LowLevel.build for the exact list of other files it must be comb
 #include <string.h>
 #include <stdlib.h>
 #include "brg_endian.h"
+#include "load-store.h"
 #include "KeccakP-1600-SnP.h"
 #include "SnP-Relaned.h"
 
@@ -397,7 +398,7 @@ void KeccakP1600_ExtractAndAddLanes(const KeccakP1600_plain64_state *state, cons
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     tSmallUInt i;
     for(i=0; i<laneCount; i++)
-        ((tKeccakLane*)output)[i] = ((tKeccakLane*)input)[i] ^ ((const tKeccakLane*)state)[i];
+        XKCP_store64(output+i*8, XKCP_load64(input+i*8) ^ state->A[i]);
 #else
     tSmallUInt i, j;
     for(i=0; i<laneCount; i++)

--- a/lib/low/KeccakP-1600/plain-32bits-inplace/KeccakP-1600-inplace32BI.c
+++ b/lib/low/KeccakP-1600/plain-32bits-inplace/KeccakP-1600-inplace32BI.c
@@ -25,6 +25,7 @@ Please refer to LowLevel.build for the exact list of other files it must be comb
 #include <stdint.h>
 #include <string.h>
 #include "brg_endian.h"
+#include "load-store.h"
 #include "KeccakP-1600-SnP.h"
 #include "SnP-Relaned.h"
 
@@ -95,8 +96,8 @@ void KeccakP1600_SetBytesInLaneToZero(KeccakP1600_plain32_state *state, unsigned
     memset(laneAsBytes+offset, 0x00, length);
     memset(laneAsBytes+offset+length, 0xFF, 8-offset-length);
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    low = *((uint32_t*)(laneAsBytes+0));
-    high = *((uint32_t*)(laneAsBytes+4));
+    low = XKCP_load32(laneAsBytes+0);
+    high = XKCP_load32(laneAsBytes+4);
 #else
     low = laneAsBytes[0]
         | ((uint32_t)(laneAsBytes[1]) << 8)
@@ -150,8 +151,8 @@ void KeccakP1600_AddBytesInLane(KeccakP1600_plain32_state *state, unsigned int l
     memset(laneAsBytes, 0, 8);
     memcpy(laneAsBytes+offset, data, length);
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    low = *((uint32_t*)(laneAsBytes+0));
-    high = *((uint32_t*)(laneAsBytes+4));
+    low = XKCP_load32(laneAsBytes+0);
+    high = XKCP_load32(laneAsBytes+4);
 #else
     low = laneAsBytes[0]
         | ((uint32_t)(laneAsBytes[1]) << 8)
@@ -170,20 +171,15 @@ void KeccakP1600_AddBytesInLane(KeccakP1600_plain32_state *state, unsigned int l
 void KeccakP1600_AddLanes(KeccakP1600_plain32_state *state, const unsigned char *data, unsigned int laneCount)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    const uint32_t * pI = (const uint32_t *)data;
+    const unsigned char * pI = data;
     uint32_t * pS = state->A;
     uint32_t t, x0, x1;
     int i;
     for (i = laneCount-1; i >= 0; --i) {
-#ifdef NO_MISALIGNED_ACCESSES
-        uint32_t low;
-        uint32_t high;
-        memcpy(&low, pI++, 4);
-        memcpy(&high, pI++, 4);
+        uint32_t low = XKCP_load32(pI);
+        uint32_t high = XKCP_load32(pI+4);
+        pI += 8;
         toBitInterleavingAndXOR(low, high, *(pS++), *(pS++), t, x0, x1);
-#else
-        toBitInterleavingAndXOR(*(pI++), *(pI++), *(pS++), *(pS++), t, x0, x1)
-#endif
     }
 #else
     unsigned int lanePosition;
@@ -225,20 +221,15 @@ void KeccakP1600_OverwriteBytesInLane(KeccakP1600_plain32_state *state, unsigned
 void KeccakP1600_OverwriteLanes(KeccakP1600_plain32_state *state, const unsigned char *data, unsigned int laneCount)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    const uint32_t * pI = (const uint32_t *)data;
-    uint32_t * pS = (uint32_t *)state;
+    const unsigned char * pI = data;
+    uint32_t * pS = state->A;
     uint32_t t, x0, x1;
     int i;
     for (i = laneCount-1; i >= 0; --i) {
-#ifdef NO_MISALIGNED_ACCESSES
-        uint32_t low;
-        uint32_t high;
-        memcpy(&low, pI++, 4);
-        memcpy(&high, pI++, 4);
+        uint32_t low = XKCP_load32(pI);
+        uint32_t high = XKCP_load32(pI+4);
+        pI += 8;
         toBitInterleavingAndSet(low, high, *(pS++), *(pS++), t, x0, x1);
-#else
-        toBitInterleavingAndSet(*(pI++), *(pI++), *(pS++), *(pS++), t, x0, x1)
-#endif
     }
 #else
     unsigned int lanePosition;
@@ -292,8 +283,8 @@ void KeccakP1600_ExtractBytesInLane(const KeccakP1600_plain32_state *state, unsi
 
     fromBitInterleaving(stateAsHalfLanes[lanePosition*2], stateAsHalfLanes[lanePosition*2+1], low, high, temp, temp0, temp1);
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    *((uint32_t*)(laneAsBytes+0)) = low;
-    *((uint32_t*)(laneAsBytes+4)) = high;
+    XKCP_store32(laneAsBytes+0, low);
+    XKCP_store32(laneAsBytes+4, high);
 #else
     laneAsBytes[0] = low & 0xFF;
     laneAsBytes[1] = (low >> 8) & 0xFF;
@@ -312,20 +303,17 @@ void KeccakP1600_ExtractBytesInLane(const KeccakP1600_plain32_state *state, unsi
 void KeccakP1600_ExtractLanes(const KeccakP1600_plain32_state *state, unsigned char *data, unsigned int laneCount)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    uint32_t * pI = (uint32_t *)data;
-    const uint32_t * pS = ( const uint32_t *)state;
+    unsigned char * pI = data;
+    const uint32_t * pS = state->A;
     uint32_t t, x0, x1;
     int i;
     for (i = laneCount-1; i >= 0; --i) {
-#ifdef NO_MISALIGNED_ACCESSES
         uint32_t low;
         uint32_t high;
         fromBitInterleaving(*(pS++), *(pS++), low, high, t, x0, x1);
-        memcpy(pI++, &low, 4);
-        memcpy(pI++, &high, 4);
-#else
-        fromBitInterleaving(*(pS++), *(pS++), *(pI++), *(pI++), t, x0, x1)
-#endif
+        XKCP_store32(pI, low);
+        XKCP_store32(pI+4, high);
+        pI += 8;
     }
 #else
     unsigned int lanePosition;
@@ -365,8 +353,8 @@ void KeccakP1600_ExtractAndAddBytesInLane(const KeccakP1600_plain32_state *state
 
     fromBitInterleaving(stateAsHalfLanes[lanePosition*2], stateAsHalfLanes[lanePosition*2+1], low, high, temp, temp0, temp1);
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    *((uint32_t*)(laneAsBytes+0)) = low;
-    *((uint32_t*)(laneAsBytes+4)) = high;
+    XKCP_store32(laneAsBytes+0, low);
+    XKCP_store32(laneAsBytes+4, high);
 #else
     laneAsBytes[0] = low & 0xFF;
     laneAsBytes[1] = (low >> 8) & 0xFF;
@@ -386,21 +374,19 @@ void KeccakP1600_ExtractAndAddBytesInLane(const KeccakP1600_plain32_state *state
 void KeccakP1600_ExtractAndAddLanes(const KeccakP1600_plain32_state *state, const unsigned char *input, unsigned char *output, unsigned int laneCount)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    const uint32_t * pI = (const uint32_t *)input;
-    uint32_t * pO = (uint32_t *)output;
-    const uint32_t * pS = (const uint32_t *)state;
+    const unsigned char * pI = input;
+    unsigned char * pO = output;
+    const uint32_t * pS = state->A;
     uint32_t t, x0, x1;
     int i;
     for (i = laneCount-1; i >= 0; --i) {
-#ifdef NO_MISALIGNED_ACCESSES
         uint32_t low;
         uint32_t high;
         fromBitInterleaving(*(pS++), *(pS++), low, high, t, x0, x1);
-        *(pO++) = *(pI++) ^ low;
-        *(pO++) = *(pI++) ^ high;
-#else
-        fromBitInterleavingAndXOR(*(pS++), *(pS++), *(pI++), *(pI++), *(pO++), *(pO++), t, x0, x1)
-#endif
+        XKCP_store32(pO, XKCP_load32(pI) ^ low);
+        XKCP_store32(pO+4, XKCP_load32(pI+4) ^ high);
+        pI += 8;
+        pO += 8;
     }
 #else
     unsigned int lanePosition;

--- a/lib/low/KeccakP-1600/plain-64bits/KeccakP-1600-opt64.c
+++ b/lib/low/KeccakP-1600/plain-64bits/KeccakP-1600-opt64.c
@@ -26,6 +26,7 @@ Please refer to LowLevel.build for the exact list of other files it must be comb
 #include <string.h>
 #include <stdlib.h>
 #include "brg_endian.h"
+#include "load-store.h"
 #include "KeccakP-1600-SnP.h"
 
 #if defined(KeccakP1600_plain64_useLaneComplementing)
@@ -125,40 +126,29 @@ void KeccakP1600_plain64_AddLanes(KeccakP1600_plain64_state *state, const unsign
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     unsigned int i = 0;
-#ifdef NO_MISALIGNED_ACCESSES
-    /* If either pointer is misaligned, fall back to byte-wise xor. */
-    if (((((uintptr_t)state) & 7) != 0) || ((((uintptr_t)data) & 7) != 0)) {
-      for (i = 0; i < laneCount * 8; i++) {
-        ((unsigned char*)state)[i] ^= data[i];
-      }
+
+    for( ; (i+8)<=laneCount; i+=8) {
+        state->A[i+0] ^= XKCP_load64(data+(i+0)*8);
+        state->A[i+1] ^= XKCP_load64(data+(i+1)*8);
+        state->A[i+2] ^= XKCP_load64(data+(i+2)*8);
+        state->A[i+3] ^= XKCP_load64(data+(i+3)*8);
+        state->A[i+4] ^= XKCP_load64(data+(i+4)*8);
+        state->A[i+5] ^= XKCP_load64(data+(i+5)*8);
+        state->A[i+6] ^= XKCP_load64(data+(i+6)*8);
+        state->A[i+7] ^= XKCP_load64(data+(i+7)*8);
     }
-    else
-#endif
-    {
-      /* Otherwise... */
-      for( ; (i+8)<=laneCount; i+=8) {
-          state->A[i+0] ^= ((uint64_t*)data)[i+0];
-          state->A[i+1] ^= ((uint64_t*)data)[i+1];
-          state->A[i+2] ^= ((uint64_t*)data)[i+2];
-          state->A[i+3] ^= ((uint64_t*)data)[i+3];
-          state->A[i+4] ^= ((uint64_t*)data)[i+4];
-          state->A[i+5] ^= ((uint64_t*)data)[i+5];
-          state->A[i+6] ^= ((uint64_t*)data)[i+6];
-          state->A[i+7] ^= ((uint64_t*)data)[i+7];
-      }
-      for( ; (i+4)<=laneCount; i+=4) {
-          state->A[i+0] ^= ((uint64_t*)data)[i+0];
-          state->A[i+1] ^= ((uint64_t*)data)[i+1];
-          state->A[i+2] ^= ((uint64_t*)data)[i+2];
-          state->A[i+3] ^= ((uint64_t*)data)[i+3];
-      }
-      for( ; (i+2)<=laneCount; i+=2) {
-          state->A[i+0] ^= ((uint64_t*)data)[i+0];
-          state->A[i+1] ^= ((uint64_t*)data)[i+1];
-      }
-      if (i<laneCount) {
-          state->A[i+0] ^= ((uint64_t*)data)[i+0];
-      }
+    for( ; (i+4)<=laneCount; i+=4) {
+        state->A[i+0] ^= XKCP_load64(data+(i+0)*8);
+        state->A[i+1] ^= XKCP_load64(data+(i+1)*8);
+        state->A[i+2] ^= XKCP_load64(data+(i+2)*8);
+        state->A[i+3] ^= XKCP_load64(data+(i+3)*8);
+    }
+    for( ; (i+2)<=laneCount; i+=2) {
+        state->A[i+0] ^= XKCP_load64(data+(i+0)*8);
+        state->A[i+1] ^= XKCP_load64(data+(i+1)*8);
+    }
+    if (i<laneCount) {
+        state->A[i+0] ^= XKCP_load64(data+(i+0)*8);
     }
 #else
     unsigned int i;
@@ -237,9 +227,9 @@ void KeccakP1600_plain64_OverwriteLanes(KeccakP1600_plain64_state *state, const 
 
     for(lanePosition=0; lanePosition<laneCount; lanePosition++)
         if ((lanePosition == 1) || (lanePosition == 2) || (lanePosition == 8) || (lanePosition == 12) || (lanePosition == 17) || (lanePosition == 20))
-            state->A[lanePosition] = ~((const uint64_t*)data)[lanePosition];
+            state->A[lanePosition] = ~XKCP_load64(data+lanePosition*8);
         else
-            state->A[lanePosition] = ((const uint64_t*)data)[lanePosition];
+            state->A[lanePosition] = XKCP_load64(data+lanePosition*8);
 #else
     memcpy(state, data, laneCount*8);
 #endif
@@ -412,21 +402,21 @@ void KeccakP1600_plain64_ExtractLanes(const KeccakP1600_plain64_state *state, un
     unsigned int i;
 
     for(i=0; i<laneCount; i++)
-        fromWordToBytes(data+(i*8), ((const uint64_t*)state)[i]);
+        fromWordToBytes(data+(i*8), state->A[i]);
 #endif
 #ifdef KeccakP1600_plain64_useLaneComplementing
     if (laneCount > 1) {
-        ((uint64_t*)data)[ 1] = ~((uint64_t*)data)[ 1];
+        XKCP_store64(data+1*8, ~XKCP_load64(data+1*8));
         if (laneCount > 2) {
-            ((uint64_t*)data)[ 2] = ~((uint64_t*)data)[ 2];
+            XKCP_store64(data+2*8, ~XKCP_load64(data+2*8));
             if (laneCount > 8) {
-                ((uint64_t*)data)[ 8] = ~((uint64_t*)data)[ 8];
+                XKCP_store64(data+8*8, ~XKCP_load64(data+8*8));
                 if (laneCount > 12) {
-                    ((uint64_t*)data)[12] = ~((uint64_t*)data)[12];
+                    XKCP_store64(data+12*8, ~XKCP_load64(data+12*8));
                     if (laneCount > 17) {
-                        ((uint64_t*)data)[17] = ~((uint64_t*)data)[17];
+                        XKCP_store64(data+17*8, ~XKCP_load64(data+17*8));
                         if (laneCount > 20) {
-                            ((uint64_t*)data)[20] = ~((uint64_t*)data)[20];
+                            XKCP_store64(data+20*8, ~XKCP_load64(data+20*8));
                         }
                     }
                 }
@@ -452,22 +442,12 @@ void KeccakP1600_plain64_ExtractAndAddBytesInLane(const KeccakP1600_plain64_stat
     if ((lanePosition == 1) || (lanePosition == 2) || (lanePosition == 8) || (lanePosition == 12) || (lanePosition == 17) || (lanePosition == 20))
         lane = ~lane;
 #endif
-#if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    {
-        unsigned int i;
-        uint64_t lane1[1];
-        lane1[0] = lane;
-        for(i=0; i<length; i++)
-            output[i] = input[i] ^ ((uint8_t*)lane1)[offset+i];
-    }
-#else
     unsigned int i;
     lane >>= offset*8;
     for(i=0; i<length; i++) {
         output[i] = input[i] ^ (lane & 0xFF);
         lane >>= 8;
     }
-#endif
 }
 
 /* ---------------------------------------------------------------- */
@@ -482,26 +462,26 @@ void KeccakP1600_plain64_ExtractAndAddLanes(const KeccakP1600_plain64_state *sta
 
     for(i=0; i<laneCount; i++) {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-        ((uint64_t*)output)[i] = ((uint64_t*)input)[i] ^ ((const uint64_t*)state)[i];
+        XKCP_store64(output+i*8, XKCP_load64(input+i*8) ^ state->A[i]);
 #else
-        fromWordToBytes(temp, ((const uint64_t*)state)[i]);
+        fromWordToBytes(temp, state->A[i]);
         for(j=0; j<8; j++)
             output[i*8+j] = input[i*8+j] ^ temp[j];
 #endif
     }
 #ifdef KeccakP1600_plain64_useLaneComplementing
     if (laneCount > 1) {
-        ((uint64_t*)output)[ 1] = ~((uint64_t*)output)[ 1];
+        XKCP_store64(output+1*8, ~XKCP_load64(output+1*8));
         if (laneCount > 2) {
-            ((uint64_t*)output)[ 2] = ~((uint64_t*)output)[ 2];
+            XKCP_store64(output+2*8, ~XKCP_load64(output+2*8));
             if (laneCount > 8) {
-                ((uint64_t*)output)[ 8] = ~((uint64_t*)output)[ 8];
+                XKCP_store64(output+8*8, ~XKCP_load64(output+8*8));
                 if (laneCount > 12) {
-                    ((uint64_t*)output)[12] = ~((uint64_t*)output)[12];
+                    XKCP_store64(output+12*8, ~XKCP_load64(output+12*8));
                     if (laneCount > 17) {
-                        ((uint64_t*)output)[17] = ~((uint64_t*)output)[17];
+                        XKCP_store64(output+17*8, ~XKCP_load64(output+17*8));
                         if (laneCount > 20) {
-                            ((uint64_t*)output)[20] = ~((uint64_t*)output)[20];
+                            XKCP_store64(output+20*8, ~XKCP_load64(output+20*8));
                         }
                     }
                 }
@@ -528,13 +508,13 @@ size_t KeccakF1600_plain64_FastLoop_Absorb(KeccakP1600_plain64_state *state, uns
     unsigned int i;
     #endif
     uint64_t *stateAsLanes = state->A;
-    uint64_t *inDataAsLanes = (uint64_t*)data;
+    const unsigned char *inData = data;
 
     copyFromState(A, stateAsLanes)
     while(dataByteLen >= laneCount*8) {
-        addInput(A, inDataAsLanes, laneCount)
+        addInput(A, inData, laneCount)
         rounds24
-        inDataAsLanes += laneCount;
+        inData += laneCount*8;
         dataByteLen -= laneCount*8;
     }
     copyToState(stateAsLanes, A)
@@ -551,13 +531,13 @@ size_t KeccakP1600_12rounds_plain64_FastLoop_Absorb(KeccakP1600_plain64_state *s
     unsigned int i;
     #endif
     uint64_t *stateAsLanes = state->A;
-    uint64_t *inDataAsLanes = (uint64_t*)data;
+    const unsigned char *inData = data;
 
     copyFromState(A, stateAsLanes)
     while(dataByteLen >= laneCount*8) {
-        addInput(A, inDataAsLanes, laneCount)
+        addInput(A, inData, laneCount)
         rounds12
-        inDataAsLanes += laneCount;
+        inData += laneCount*8;
         dataByteLen -= laneCount*8;
     }
     copyToState(stateAsLanes, A)
@@ -571,40 +551,40 @@ size_t KeccakP1600_12rounds_plain64_FastLoop_Absorb(KeccakP1600_plain64_state *s
 
 #define mStateOut160( __s )         __s[20] = Asa; __s[21] = Ase; __s[22] = Asi; __s[23] = Aso; __s[24] = Asu
 
-#define mStateOver160( __i )        Aba = __i[ 0]; Abe = __i[ 1]; Abi = __i[ 2]; Abo = __i[ 3]; Abu = __i[ 4]; \
-                                    Aga = __i[ 5]; Age = __i[ 6]; Agi = __i[ 7]; Ago = __i[ 8]; Agu = __i[ 9]; \
-                                    Aka = __i[10]; Ake = __i[11]; Aki = __i[12]; Ako = __i[13]; Aku = __i[14]; \
-                                    Ama = __i[15]; Ame = __i[16]; Ami = __i[17]; Amo = __i[18]; Amu = __i[19]
+#define mStateOver160( __i )        Aba = XKCP_load64(__i+0*8); Abe = XKCP_load64(__i+1*8); Abi = XKCP_load64(__i+2*8); Abo = XKCP_load64(__i+3*8); Abu = XKCP_load64(__i+4*8); \
+                                    Aga = XKCP_load64(__i+5*8); Age = XKCP_load64(__i+6*8); Agi = XKCP_load64(__i+7*8); Ago = XKCP_load64(__i+8*8); Agu = XKCP_load64(__i+9*8); \
+                                    Aka = XKCP_load64(__i+10*8); Ake = XKCP_load64(__i+11*8); Aki = XKCP_load64(__i+12*8); Ako = XKCP_load64(__i+13*8); Aku = XKCP_load64(__i+14*8); \
+                                    Ama = XKCP_load64(__i+15*8); Ame = XKCP_load64(__i+16*8); Ami = XKCP_load64(__i+17*8); Amo = XKCP_load64(__i+18*8); Amu = XKCP_load64(__i+19*8)
 
 #define mStateNoInput160()          Aba = 1; Abe = 0; Abi = 0; Abo = 0; Abu = 0; \
                                     Aga = 0; Age = 0; Agi = 0; Ago = 0; Agu = 0; \
                                     Aka = 0; Ake = 0; Aki = 0; Ako = 0; Aku = 0; \
                                     Ama = 0; Ame = 0; Ami = 0; Amo = 0; Amu = 0
 
-#define mStateExtr160( __o, __oA )  __o[ 0] = Aba ^ __oA[ 0]; __o[ 1] = Abe ^ __oA[ 1]; __o[ 2] = Abi ^ __oA[ 2]; __o[ 3] = Abo ^ __oA[ 3]; __o[ 4] = Abu ^ __oA[ 4]; \
-                                    __o[ 5] = Aga ^ __oA[ 5]; __o[ 6] = Age ^ __oA[ 6]; __o[ 7] = Agi ^ __oA[ 7]; __o[ 8] = Ago ^ __oA[ 8]; __o[ 9] = Agu ^ __oA[ 9]; \
-                                    __o[10] = Aka ^ __oA[10]; __o[11] = Ake ^ __oA[11]; __o[12] = Aki ^ __oA[12]; __o[13] = Ako ^ __oA[13]; __o[14] = Aku ^ __oA[14]; \
-                                    __o[15] = Ama ^ __oA[15]; __o[16] = Ame ^ __oA[16]; __o[17] = Ami ^ __oA[17]; __o[18] = Amo ^ __oA[18]; __o[19] = Amu ^ __oA[19]
+#define mStateExtr160( __o, __oA )  XKCP_store64(__o+0*8, Aba ^ XKCP_load64(__oA+0*8)); XKCP_store64(__o+1*8, Abe ^ XKCP_load64(__oA+1*8)); XKCP_store64(__o+2*8, Abi ^ XKCP_load64(__oA+2*8)); XKCP_store64(__o+3*8, Abo ^ XKCP_load64(__oA+3*8)); XKCP_store64(__o+4*8, Abu ^ XKCP_load64(__oA+4*8)); \
+                                    XKCP_store64(__o+5*8, Aga ^ XKCP_load64(__oA+5*8)); XKCP_store64(__o+6*8, Age ^ XKCP_load64(__oA+6*8)); XKCP_store64(__o+7*8, Agi ^ XKCP_load64(__oA+7*8)); XKCP_store64(__o+8*8, Ago ^ XKCP_load64(__oA+8*8)); XKCP_store64(__o+9*8, Agu ^ XKCP_load64(__oA+9*8)); \
+                                    XKCP_store64(__o+10*8, Aka ^ XKCP_load64(__oA+10*8)); XKCP_store64(__o+11*8, Ake ^ XKCP_load64(__oA+11*8)); XKCP_store64(__o+12*8, Aki ^ XKCP_load64(__oA+12*8)); XKCP_store64(__o+13*8, Ako ^ XKCP_load64(__oA+13*8)); XKCP_store64(__o+14*8, Aku ^ XKCP_load64(__oA+14*8)); \
+                                    XKCP_store64(__o+15*8, Ama ^ XKCP_load64(__oA+15*8)); XKCP_store64(__o+16*8, Ame ^ XKCP_load64(__oA+16*8)); XKCP_store64(__o+17*8, Ami ^ XKCP_load64(__oA+17*8)); XKCP_store64(__o+18*8, Amo ^ XKCP_load64(__oA+18*8)); XKCP_store64(__o+19*8, Amu ^ XKCP_load64(__oA+19*8))
 
 // r = 128
 #define mStateIn128( __s )          mStateIn160( __s ); Ame = __s[16]; Ami = __s[17]; Amo = __s[18]; Amu = __s[19]
 
 #define mStateOut128( __s )         mStateOut160( __s ); __s[16] = Ame; __s[17] = Ami; __s[18] = Amo; __s[19] = Amu
 
-#define mStateOver128( __i )        Aba = __i[ 0]; Abe = __i[ 1]; Abi = __i[ 2]; Abo = __i[ 3]; Abu = __i[ 4]; \
-                                    Aga = __i[ 5]; Age = __i[ 6]; Agi = __i[ 7]; Ago = __i[ 8]; Agu = __i[ 9]; \
-                                    Aka = __i[10]; Ake = __i[11]; Aki = __i[12]; Ako = __i[13]; Aku = __i[14]; \
-                                    Ama = __i[15]
+#define mStateOver128( __i )        Aba = XKCP_load64(__i+0*8); Abe = XKCP_load64(__i+1*8); Abi = XKCP_load64(__i+2*8); Abo = XKCP_load64(__i+3*8); Abu = XKCP_load64(__i+4*8); \
+                                    Aga = XKCP_load64(__i+5*8); Age = XKCP_load64(__i+6*8); Agi = XKCP_load64(__i+7*8); Ago = XKCP_load64(__i+8*8); Agu = XKCP_load64(__i+9*8); \
+                                    Aka = XKCP_load64(__i+10*8); Ake = XKCP_load64(__i+11*8); Aki = XKCP_load64(__i+12*8); Ako = XKCP_load64(__i+13*8); Aku = XKCP_load64(__i+14*8); \
+                                    Ama = XKCP_load64(__i+15*8)
 
 #define mStateNoInput128()          Aba = 1; Abe = 0; Abi = 0; Abo = 0; Abu = 0; \
                                     Aga = 0; Age = 0; Agi = 0; Ago = 0; Agu = 0; \
                                     Aka = 0; Ake = 0; Aki = 0; Ako = 0; Aku = 0; \
                                     Ama = 0
 
-#define mStateExtr128( __o, __oA )  __o[ 0] = Aba ^ __oA[ 0]; __o[ 1] = Abe ^ __oA[ 1]; __o[ 2] = Abi ^ __oA[ 2]; __o[ 3] = Abo ^ __oA[ 3]; __o[ 4] = Abu ^ __oA[ 4]; \
-                                    __o[ 5] = Aga ^ __oA[ 5]; __o[ 6] = Age ^ __oA[ 6]; __o[ 7] = Agi ^ __oA[ 7]; __o[ 8] = Ago ^ __oA[ 8]; __o[ 9] = Agu ^ __oA[ 9]; \
-                                    __o[10] = Aka ^ __oA[10]; __o[11] = Ake ^ __oA[11]; __o[12] = Aki ^ __oA[12]; __o[13] = Ako ^ __oA[13]; __o[14] = Aku ^ __oA[14]; \
-                                    __o[15] = Ama ^ __oA[15]
+#define mStateExtr128( __o, __oA )  XKCP_store64(__o+0*8, Aba ^ XKCP_load64(__oA+0*8)); XKCP_store64(__o+1*8, Abe ^ XKCP_load64(__oA+1*8)); XKCP_store64(__o+2*8, Abi ^ XKCP_load64(__oA+2*8)); XKCP_store64(__o+3*8, Abo ^ XKCP_load64(__oA+3*8)); XKCP_store64(__o+4*8, Abu ^ XKCP_load64(__oA+4*8)); \
+                                    XKCP_store64(__o+5*8, Aga ^ XKCP_load64(__oA+5*8)); XKCP_store64(__o+6*8, Age ^ XKCP_load64(__oA+6*8)); XKCP_store64(__o+7*8, Agi ^ XKCP_load64(__oA+7*8)); XKCP_store64(__o+8*8, Ago ^ XKCP_load64(__oA+8*8)); XKCP_store64(__o+9*8, Agu ^ XKCP_load64(__oA+9*8)); \
+                                    XKCP_store64(__o+10*8, Aka ^ XKCP_load64(__oA+10*8)); XKCP_store64(__o+11*8, Ake ^ XKCP_load64(__oA+11*8)); XKCP_store64(__o+12*8, Aki ^ XKCP_load64(__oA+12*8)); XKCP_store64(__o+13*8, Ako ^ XKCP_load64(__oA+13*8)); XKCP_store64(__o+14*8, Aku ^ XKCP_load64(__oA+14*8)); \
+                                    XKCP_store64(__o+15*8, Ama ^ XKCP_load64(__oA+15*8))
 
 // Whole state
 #define mStateOutAll( __s )         __s[ 0] = Aba; __s[ 1] = Abe; __s[ 2] = Abi; __s[ 3] = Abo; __s[ 4] = Abu; \
@@ -617,10 +597,10 @@ size_t KeccakP1600_12rounds_plain64_FastLoop_Absorb(KeccakP1600_plain64_state *s
 
 #define ODDuplexingFastInOut(RHO, trailerLane, rounds) \
     size_t originalDataByteLen = len; \
-    uint64_t        *stateAsLanes       = (uint64_t*)state; \
-    const uint64_t  *inDataAsLanes      = (const uint64_t*)idata; \
-    uint64_t        *outDataAsLanes     = (uint64_t*)odata; \
-    const uint64_t  *outDataAddAsLanes  = (const uint64_t*)odataAdd; \
+    uint64_t        *stateAsLanes       = state->A; \
+    const unsigned char *inDataAsLanes  = idata; \
+    unsigned char   *outDataAsLanes     = odata; \
+    const unsigned char *outDataAddAsLanes = odataAdd; \
     \
     mStateIn##RHO( stateAsLanes ); \
     while ( len >= RHO ) { \
@@ -628,9 +608,9 @@ size_t KeccakP1600_12rounds_plain64_FastLoop_Absorb(KeccakP1600_plain64_state *s
         trailerLane ^= trailencAsLane; \
         rounds \
         mStateExtr##RHO( outDataAsLanes, outDataAddAsLanes ); \
-        inDataAsLanes       += RHO / 8; \
-        outDataAsLanes      += RHO / 8; \
-        outDataAddAsLanes   += RHO / 8; \
+        inDataAsLanes       += RHO; \
+        outDataAsLanes      += RHO; \
+        outDataAddAsLanes   += RHO; \
         len                 -= RHO; \
     } \
     mStateOut##RHO( stateAsLanes ); \
@@ -677,9 +657,9 @@ size_t KeccakP1600_12rounds_plain64_ODDuplexingFastInOut(KeccakP1600_plain64_sta
 
 #define ODDuplexingFastOut(RHO, trailerLane, rounds) \
     size_t originalDataByteLen = len; \
-    uint64_t        *stateAsLanes       = (uint64_t*)state; \
-    uint64_t        *outDataAsLanes     = (uint64_t*)odata; \
-    const uint64_t  *outDataAddAsLanes  = (const uint64_t*)odataAdd; \
+    uint64_t        *stateAsLanes       = state->A; \
+    unsigned char   *outDataAsLanes     = odata; \
+    const unsigned char *outDataAddAsLanes = odataAdd; \
     \
     mStateIn##RHO( stateAsLanes ); \
     while ( len >= RHO ) { \
@@ -687,8 +667,8 @@ size_t KeccakP1600_12rounds_plain64_ODDuplexingFastInOut(KeccakP1600_plain64_sta
         trailerLane ^= trailencAsLane; \
         rounds \
         mStateExtr##RHO( outDataAsLanes, outDataAddAsLanes ); \
-        outDataAsLanes      += RHO / 8; \
-        outDataAddAsLanes   += RHO / 8; \
+        outDataAsLanes      += RHO; \
+        outDataAddAsLanes   += RHO; \
         len                 -= RHO; \
     } \
     mStateOut##RHO( stateAsLanes ); \
@@ -735,15 +715,15 @@ size_t KeccakP1600_12rounds_plain64_ODDuplexingFastOut(KeccakP1600_plain64_state
 
 #define ODDuplexingFastIn(RHO, trailerLane, rounds) \
     size_t originalDataByteLen = len; \
-    uint64_t        *stateAsLanes       = (uint64_t*)state; \
-    const uint64_t  *inDataAsLanes      = (const uint64_t*)idata; \
+    uint64_t        *stateAsLanes       = state->A; \
+    const unsigned char *inDataAsLanes  = idata; \
     \
     mStateIn##RHO( stateAsLanes ); \
     while ( len > RHO ) { \
         mStateOver##RHO( inDataAsLanes ); \
         trailerLane ^= trailencAsLane; \
         rounds \
-        inDataAsLanes   += RHO / 8; \
+        inDataAsLanes   += RHO; \
         len             -= RHO; \
     } \
     mStateOutAll( stateAsLanes ); \

--- a/lib/low/KeccakP-1600/ref-64bits/KeccakP-1600-reference.c
+++ b/lib/low/KeccakP-1600/ref-64bits/KeccakP-1600-reference.c
@@ -195,10 +195,8 @@ void KeccakP1600_OverwriteWithZeroes(KeccakP1600_plain8_state *state, unsigned i
 
 /* ---------------------------------------------------------------- */
 
-#if (PLATFORM_BYTE_ORDER != IS_LITTLE_ENDIAN)
 static void fromBytesToWords(tKeccakLane *stateAsWords, const unsigned char *state);
 static void fromWordsToBytes(unsigned char *state, const tKeccakLane *stateAsWords);
-#endif
 void KeccakP1600OnWords(tKeccakLane *state, unsigned int nrRounds);
 void KeccakP1600Round(tKeccakLane *state, unsigned int indexRound);
 static void theta(tKeccakLane *A);
@@ -209,20 +207,14 @@ static void iota(tKeccakLane *A, unsigned int indexRound);
 
 void KeccakP1600_Permute_Nrounds(KeccakP1600_plain8_state *state, unsigned int nrounds)
 {
-#if (PLATFORM_BYTE_ORDER != IS_LITTLE_ENDIAN)
     tKeccakLane stateAsWords[1600/64];
-#endif
 
 #ifdef KeccakReference
     displayStateAsBytes(1, "Input of permutation", (const unsigned char *)state->A, 1600);
 #endif
-#if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
-    KeccakP1600OnWords((tKeccakLane*)state->A, nrounds);
-#else
     fromBytesToWords(stateAsWords, state->A);
     KeccakP1600OnWords(stateAsWords, nrounds);
     fromWordsToBytes(state->A, stateAsWords);
-#endif
 #ifdef KeccakReference
     displayStateAsBytes(1, "State after permutation", (const unsigned char *)state->A, 1600);
 #endif
@@ -238,7 +230,6 @@ void KeccakP1600_Permute_24rounds(KeccakP1600_plain8_state *state)
     KeccakP1600_Permute_Nrounds(state, 24);
 }
 
-#if (PLATFORM_BYTE_ORDER != IS_LITTLE_ENDIAN)
 static void fromBytesToWords(tKeccakLane *stateAsWords, const uint8_t *state)
 {
     unsigned int i, j;
@@ -258,7 +249,6 @@ static void fromWordsToBytes(uint8_t *state, const tKeccakLane *stateAsWords)
         for(j=0; j<(64/8); j++)
             state[i*(64/8)+j] = (uint8_t)((stateAsWords[i] >> (8*j)) & 0xFF);
 }
-#endif
 
 void KeccakP1600OnWords(tKeccakLane *state, unsigned int nrRounds)
 {

--- a/lib/low/Xoodoo/Xoodoo.h
+++ b/lib/low/Xoodoo/Xoodoo.h
@@ -18,6 +18,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #define _Xoodoo_h_
 
 #include <stdint.h>
+#include "load-store.h"
 #include <stdlib.h>
 
 #define MAXROUNDS   12
@@ -51,23 +52,11 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #endif
 
 #if !defined(READ32_UNALIGNED)
-    #if defined (__arm__) && !defined(__GNUC__)
-        #define READ32_UNALIGNED(argAddress)            (*((const __packed uint32_t*)(argAddress)))
-    #elif defined(_MSC_VER)
-        #define READ32_UNALIGNED(argAddress)            (*((const uint32_t*)(argAddress)))
-    #else
-        #define READ32_UNALIGNED(argAddress)            (*((const uint32_t*)(argAddress)))
-    #endif
+    #define READ32_UNALIGNED(argAddress)            XKCP_load32(argAddress)
 #endif
 
 #if !defined(WRITE32_UNALIGNED)
-    #if defined (__arm__) && !defined(__GNUC__)
-        #define WRITE32_UNALIGNED(argAddress, argData)  (*((__packed uint32_t*)(argAddress)) = (argData))
-    #elif defined(_MSC_VER)
-        #define WRITE32_UNALIGNED(argAddress, argData)  (*((uint32_t*)(argAddress)) = (argData))
-    #else
-        #define WRITE32_UNALIGNED(argAddress, argData)  (*((uint32_t*)(argAddress)) = (argData))
-    #endif
+    #define WRITE32_UNALIGNED(argAddress, argData)  XKCP_store32((argAddress), (argData))
 #endif
 
 #if !defined(index)

--- a/lib/low/Xoodoo/plain/Xoodoo-plain.c
+++ b/lib/low/Xoodoo/plain/Xoodoo-plain.c
@@ -62,19 +62,18 @@ void Xoodoo_plain_AddBytes(Xoodoo_plain32_state *argState, const unsigned char *
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     if (length == (3*4*4)) {
         uint32_t *state = argState->A;
-        uint32_t *data = (uint32_t *)argdata;
-        state[0] ^= data[0];
-        state[1] ^= data[1];
-        state[2] ^= data[2];
-        state[3] ^= data[3];
-        state[4] ^= data[4];
-        state[5] ^= data[5];
-        state[6] ^= data[6];
-        state[7] ^= data[7];
-        state[8] ^= data[8];
-        state[9] ^= data[9];
-        state[10] ^= data[10];
-        state[11] ^= data[11];
+        state[0] ^= XKCP_load32(argdata+0*4);
+        state[1] ^= XKCP_load32(argdata+1*4);
+        state[2] ^= XKCP_load32(argdata+2*4);
+        state[3] ^= XKCP_load32(argdata+3*4);
+        state[4] ^= XKCP_load32(argdata+4*4);
+        state[5] ^= XKCP_load32(argdata+5*4);
+        state[6] ^= XKCP_load32(argdata+6*4);
+        state[7] ^= XKCP_load32(argdata+7*4);
+        state[8] ^= XKCP_load32(argdata+8*4);
+        state[9] ^= XKCP_load32(argdata+9*4);
+        state[10] ^= XKCP_load32(argdata+10*4);
+        state[11] ^= XKCP_load32(argdata+11*4);
     }
     else {
         unsigned int sizeLeft = length;
@@ -119,19 +118,18 @@ void Xoodoo_plain_OverwriteBytes(Xoodoo_plain32_state *argstate, const unsigned 
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     if (length == (3*4*4)) {
         uint32_t *state = argstate->A;
-        uint32_t *data = (uint32_t *)argdata;
-        state[0] = data[0];
-        state[1] = data[1];
-        state[2] = data[2];
-        state[3] = data[3];
-        state[4] = data[4];
-        state[5] = data[5];
-        state[6] = data[6];
-        state[7] = data[7];
-        state[8] = data[8];
-        state[9] = data[9];
-        state[10] = data[10];
-        state[11] = data[11];
+        state[0] = XKCP_load32(argdata+0*4);
+        state[1] = XKCP_load32(argdata+1*4);
+        state[2] = XKCP_load32(argdata+2*4);
+        state[3] = XKCP_load32(argdata+3*4);
+        state[4] = XKCP_load32(argdata+4*4);
+        state[5] = XKCP_load32(argdata+5*4);
+        state[6] = XKCP_load32(argdata+6*4);
+        state[7] = XKCP_load32(argdata+7*4);
+        state[8] = XKCP_load32(argdata+8*4);
+        state[9] = XKCP_load32(argdata+9*4);
+        state[10] = XKCP_load32(argdata+10*4);
+        state[11] = XKCP_load32(argdata+11*4);
     }
     else
         memcpy((unsigned char*)argstate+offset, argdata, length);
@@ -169,21 +167,19 @@ void Xoodoo_plain_ExtractAndAddBytes(const Xoodoo_plain32_state *argState, const
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     if (length == (3*4*4)) {
         const uint32_t *state = argState->A;
-        const uint32_t *ii = (const uint32_t *)input;
-        uint32_t *oo = (uint32_t *)output;
 
-        oo[0] = state[0] ^ ii[0];
-        oo[1] = state[1] ^ ii[1];
-        oo[2] = state[2] ^ ii[2];
-        oo[3] = state[3] ^ ii[3];
-        oo[4] = state[4] ^ ii[4];
-        oo[5] = state[5] ^ ii[5];
-        oo[6] = state[6] ^ ii[6];
-        oo[7] = state[7] ^ ii[7];
-        oo[8] = state[8] ^ ii[8];
-        oo[9] = state[9] ^ ii[9];
-        oo[10] = state[10] ^ ii[10];
-        oo[11] = state[11] ^ ii[11];
+        XKCP_store32(output+0*4, state[0] ^ XKCP_load32(input+0*4));
+        XKCP_store32(output+1*4, state[1] ^ XKCP_load32(input+1*4));
+        XKCP_store32(output+2*4, state[2] ^ XKCP_load32(input+2*4));
+        XKCP_store32(output+3*4, state[3] ^ XKCP_load32(input+3*4));
+        XKCP_store32(output+4*4, state[4] ^ XKCP_load32(input+4*4));
+        XKCP_store32(output+5*4, state[5] ^ XKCP_load32(input+5*4));
+        XKCP_store32(output+6*4, state[6] ^ XKCP_load32(input+6*4));
+        XKCP_store32(output+7*4, state[7] ^ XKCP_load32(input+7*4));
+        XKCP_store32(output+8*4, state[8] ^ XKCP_load32(input+8*4));
+        XKCP_store32(output+9*4, state[9] ^ XKCP_load32(input+9*4));
+        XKCP_store32(output+10*4, state[10] ^ XKCP_load32(input+10*4));
+        XKCP_store32(output+11*4, state[11] ^ XKCP_load32(input+11*4));
     }
     else {
         unsigned int sizeLeft = length;

--- a/tests/MemoryAlignment/misalign-test.c
+++ b/tests/MemoryAlignment/misalign-test.c
@@ -1,0 +1,131 @@
+/*
+Misaligned-buffer test for XKCP.
+
+Feeds deliberately misaligned input/output/key buffers (offsets 1..7 from
+an aligned arena) through the public API and checks that the results match
+the same computation on aligned buffers.
+
+Two failure modes it detects in unpatched code:
+- Built with -fsanitize=alignment (clang), every misaligned lane access in
+  the library is reported as a runtime error, deterministically, on any
+  architecture -- including x86-64 and AArch64, whose hardware would
+  otherwise tolerate the access silently.
+- On strict-alignment hardware (e.g. 32-bit ARM), the unpatched library
+  crashes with a bus error outright.
+
+Exit code 0 = all aligned/misaligned result pairs match.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include "config.h"
+#include "align.h"
+#include "SimpleFIPS202.h"
+#include "KeccakHash.h"
+#include "SP800-185.h"
+#ifdef XKCP_has_Xoodyak
+#include "Xoodyak.h"
+#endif
+
+#define INLEN  1000
+#define OUTLEN 136     /* > one rate block of SHAKE256, exercises ExtractLanes */
+#define KEYLEN 32
+
+ALIGN(64) static unsigned char arena_in[INLEN + 64];
+ALIGN(64) static unsigned char arena_out[OUTLEN + 64];
+ALIGN(64) static unsigned char arena_key[KEYLEN + 64];
+
+static int nFailed = 0;
+
+static void check(const char *what, unsigned int offset,
+                  const unsigned char *ref, const unsigned char *got, size_t len)
+{
+    if (memcmp(ref, got, len) != 0) {
+        printf("MISMATCH: %s at offset %u\n", what, offset);
+        nFailed++;
+    }
+}
+
+int main(void)
+{
+    unsigned char refSHA3[32], refSHAKE[OUTLEN], refKMAC[32], refInc[32];
+#ifdef XKCP_has_Xoodyak
+    unsigned char refXoodyak[32];
+#endif
+    unsigned int offset, i;
+
+    for (i = 0; i < INLEN; i++)
+        arena_in[i] = (unsigned char)(i * 7 + 1);
+    for (i = 0; i < KEYLEN; i++)
+        arena_key[i] = (unsigned char)(0x40 + i);
+
+    /* Reference results on aligned buffers (offset 0). */
+    SHA3_256(refSHA3, arena_in, INLEN);
+    SHAKE256(refSHAKE, OUTLEN, arena_in, INLEN);
+    KMAC128(arena_key, KEYLEN*8, arena_in, INLEN*8, refKMAC, 256, NULL, 0);
+    {
+        Keccak_HashInstance h;
+        Keccak_HashInitialize_SHA3_256(&h);
+        Keccak_HashUpdate(&h, arena_in, 7*8);
+        Keccak_HashUpdate(&h, arena_in + 7, (INLEN - 7)*8);
+        Keccak_HashFinal(&h, refInc);
+    }
+#ifdef XKCP_has_Xoodyak
+    {
+        Xoodyak_Instance x;
+        Xoodyak_Initialize(&x, NULL, 0, NULL, 0, NULL, 0);
+        Xoodyak_Absorb(&x, arena_in, INLEN);
+        Xoodyak_Squeeze(&x, refXoodyak, 32);
+    }
+#endif
+
+    for (offset = 1; offset < 8; offset++) {
+        unsigned char *in  = arena_in  + offset;   /* misaligned input  */
+        unsigned char *out = arena_out + offset;   /* misaligned output */
+        unsigned char *key = arena_key + offset;   /* misaligned key    */
+        unsigned char aref[64];
+
+        memmove(in, arena_in, INLEN);              /* same content, shifted */
+        memmove(key, arena_key, KEYLEN);
+
+        /* one-shot hash, misaligned input and output */
+        SHA3_256(out, in, INLEN);
+        check("SHA3-256", offset, refSHA3, out, 32);
+
+        /* XOF with long misaligned output (ExtractLanes path) */
+        SHAKE256(out, OUTLEN, in, INLEN);
+        check("SHAKE256", offset, refSHAKE, out, OUTLEN);
+
+        /* MAC, all three buffers misaligned */
+        KMAC128(key, KEYLEN*8, in, INLEN*8, out, 256, NULL, 0);
+        check("KMAC128", offset, refKMAC, out, 32);
+
+        /* incremental hashing with a non-lane-multiple first chunk,
+           so the second chunk enters AddLanes/FastLoop misaligned */
+        {
+            Keccak_HashInstance h;
+            Keccak_HashInitialize_SHA3_256(&h);
+            Keccak_HashUpdate(&h, in, 7*8);
+            Keccak_HashUpdate(&h, in + 7, (INLEN - 7)*8);
+            Keccak_HashFinal(&h, aref);
+            check("SHA3-256 incremental", offset, refInc, aref, 32);
+        }
+
+#ifdef XKCP_has_Xoodyak
+        {
+            Xoodyak_Instance x;
+            Xoodyak_Initialize(&x, NULL, 0, NULL, 0, NULL, 0);
+            Xoodyak_Absorb(&x, in, INLEN);
+            Xoodyak_Squeeze(&x, out, 32);
+            check("Xoodyak", offset, refXoodyak, out, 32);
+        }
+#endif
+
+        memmove(arena_in, in, INLEN);              /* restore for next round */
+        memmove(arena_key, key, KEYLEN);
+    }
+
+    if (nFailed == 0)
+        printf("All misaligned-buffer results match the aligned references.\n");
+    return nFailed != 0;
+}

--- a/tests/MemoryAlignment/run.sh
+++ b/tests/MemoryAlignment/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Build an XKCP target with clang's or gcc's alignment sanitizer and run the
+# misaligned-buffer test against it. Needs compiler-rt installed for clang or
+# libubsan installed for gcc.
+#
+# Usage: run.sh <xkcp-tree> [target]      (default target: generic64)
+#
+# Pass/fail criteria:
+#   - any "runtime error" from UBSan  -> misaligned lane access in the library
+#   - nonzero harness exit            -> wrong results on misaligned buffers
+set -u
+TREE=${1:?usage: run.sh <xkcp-tree> [target]}
+TARGET=${2:-generic64}
+HERE=$(cd "$(dirname "$0")" && pwd)
+COMPILER="${COMPILER:-clang}"
+SAN="-fsanitize=alignment -g -O1"
+
+WRAP=$(mktemp /tmp/cc-ubsan.XXXXXX)
+printf '#!/bin/sh\nexec %s %s "$@"\n' "$COMPILER" "$SAN" > "$WRAP"
+chmod +x "$WRAP"
+trap 'rm -f "$WRAP"' EXIT
+
+cd "$TREE"
+rm -rf bin/.build
+make CC="$WRAP" "$TARGET/libXKCP.so" > /dev/null || { echo "library build failed"; exit 2; }
+
+$COMPILER $SAN -I "bin/$TARGET/libXKCP.so.headers" "$HERE/misalign-test.c" \
+    "bin/$TARGET/libXKCP.so" -o "/tmp/misalign-test-$TARGET" || exit 2
+
+LOG=/tmp/misalign-$TARGET.log
+LD_LIBRARY_PATH="$TREE/bin/$TARGET" "/tmp/misalign-test-$TARGET" > "$LOG" 2>&1
+RC=$?
+ERRS=$(grep -c "runtime error" "$LOG")
+
+echo "== $TARGET in $TREE =="
+echo "   UBSan alignment errors: $ERRS"
+echo "   result mismatches:      $(grep -c MISMATCH "$LOG") (harness rc=$RC)"
+grep "runtime error" "$LOG" | sed 's/.*runtime error/   e.g./' | sort -u | head -3
+if [ "$ERRS" -eq 0 ] && [ "$RC" -eq 0 ]; then
+    echo "   PASS"
+    exit 0
+else
+    echo "   FAIL (full log: $LOG)"
+    exit 1
+fi


### PR DESCRIPTION
# Fix unaligned and aliasing-violating lane accesses in portable code

Fixes #124.

## Problem

The portable C implementations read and write 64-bit and 32-bit lanes in caller-supplied byte buffers through pointer casts (`((uint64_t*)data)[i]`, `(uint32_t*)input`, ...). As reported in #124, this crashes with a bus error on strict-alignment targets (reproduced there on ARMv8 with a 32-bit toolchain under QEMU), and it violates strict aliasing on every target. Building with `-fstrict-aliasing -Wcast-align=strict` surfaces ~80 distinct sites across the portable implementations and the high-level Xoofff/Kravatte code.

The tree already contained three partial workarounds for this, all off by default and each covering a different corner: the `NO_MISALIGNED_ACCESSES` runtime alignment check in the plain-64bits `AddLanes`, the `NO_MISALIGNED_ACCESSES` memcpy variants in inplace32BI, and the `__packed` compiler branch of `READ32_UNALIGNED`/`WRITE32_UNALIGNED` in Xoodoo.h.

## Approach

A new header, `lib/common/load-store.h`, provides `XKCP_load32/64()` and `XKCP_store32/64()`: memcpy-based accessors that compile to a single load or store on architectures with misaligned-access support and to a safe byte sequence elsewhere, with no aliasing violation. Every lane access into a caller buffer in the portable code now goes through them:

- **KeccakP-1600 plain-64bits**: `AddLanes`, `OverwriteLanes`, `ExtractLanes`, `ExtractAndAddLanes`, both `FastLoop_Absorb` variants (via a new `loadInputLane()` macro that replaces `HTOLE64` in `KeccakP-1600-64.macros`), and the overwrite-duplexing fast paths. `ExtractAndAddBytesInLane` now uses the shift-based extraction on both endiannesses (they were semantically identical).
- **KeccakP-1600 inplace32BI**: the four lane loops and the in-lane byte handling — the former `NO_MISALIGNED_ACCESSES` variant is now the only variant.
- **KeccakP-1600 compact64**: `ExtractAndAddLanes`.
- **KeccakP-1600 ref-64bits**: the permutation now always goes through the lane-array conversion (an identity transform on little-endian; this is the reference implementation, where clarity beats the one redundant copy).
- **Xoodoo.h**: `READ32_UNALIGNED`/`WRITE32_UNALIGNED` are now genuinely unaligned-safe for all compilers, which covers the Xoodoo SSSE3/AVX-512 Xoodyak users of these macros as well.
- **Xoodoo plain**: the full-block fast paths in `AddBytes`/`OverwriteBytes`/`ExtractAndAddBytes`.
- **Xoofff / Kravatte**: `Xoofff_Rollc/Rolle` and `Kravatte_Rollc/Rolle` take the accumulator as a byte buffer (the Xoofff variants work on a local lane array, copied in and out once per call); the 64-bit XOR loops in `Xoofff_AddIs_dispatch` and KravatteModes' `memxoris` are now unconditional and safe.

With the safe path being the only path — at no cost on lax-alignment targets — the `NO_MISALIGNED_ACCESSES` conditionals are removed.

## Deliberately not changed

- The x86 SIMD implementations: their vector-pointer casts feed `_mm*_loadu`/`storeu`-style intrinsics, where the intrinsic defines the alignment semantics and the vector types may alias. `-Wcast-align=strict` still flags these, but they are the standard intrinsic idiom.
- The PlSnP `KravatteCompress`/`KravatteExpand` interface still takes `uint64_t*`; the two remaining casts in Kravatte.c are valid because the accumulators are `ALIGN()`ed struct fields. Retyping that interface to byte pointers (which would also touch the AVX2/AVX-512 backends) is possible follow-up work.

## Validation

- `-fstrict-aliasing -Wcast-align=strict`: the `reference`, `compact`, `generic32`, `generic32lc`, `generic64` and `generic64lc` targets now build with **zero warnings** (GCC).
- clang `scan-build`: zero diagnostics on the portable targets (it previously reported two "garbage value" false positives in functions this PR restructures).
- `UnitTests --all` passes for `reference`, `compact`, `generic32`, `generic32lc`, `generic64` and `x86-64`. On `generic64lc`, every suite passes except `--ShakingUpAE`, which fails identically on unpatched master — that is a pre-existing, unrelated bug (the overwrite-duplexing fast path does not handle lane complementing) and is addressed separately.
- Benchmarks (x86-64 Ice Lake, core-pinned, this branch vs. its merge base): `generic64` and `generic32` are unchanged within measurement noise (asymptotic cycles/byte within ±1%), and `compact` improves by ~5% across the board. Compilers fold the memcpy accessors into single moves; the disassembly of `AddLanes`/`FastLoop_Absorb` is essentially identical to before.

## Test Harness

I've added a test harness in `tests/MemoryAlignment` designed to use clang+compiler-rt or gcc+libubsan to try and detect alignment problems. 