### PR TITLE
Fix regression for MSVC builds

### DIFF
--- a/lib/low/Xoodoo/AVX512/Xoodyak-AVX512.c
+++ b/lib/low/Xoodoo/AVX512/Xoodyak-AVX512.c
@@ -120,7 +120,13 @@ ALIGN(16) static const uint8_t maskRhoEast2[16] = {
                         a2 = _mm_shuffle_epi8( a2, rhoEast2);                   \
                         Dump3("Rho-east")
 
-static const uint32_t    RC[MAXROUNDS] __attribute__((unused)) = {
+#if defined(__GNUC__) || defined(__clang__)
+    #define UNUSED __attribute__((unused))
+#else
+    #define UNUSED
+#endif
+
+static const uint32_t    RC[MAXROUNDS] UNUSED = {
     _rc12,
     _rc11,
     _rc10,

--- a/lib/low/Xoodoo/SSSE3/Xoodyak-SSSE3.c
+++ b/lib/low/Xoodoo/SSSE3/Xoodyak-SSSE3.c
@@ -143,7 +143,13 @@ ALIGN(16) static const uint8_t maskRhoEast2[16] = {
                         Rho_east();             \
                         Dump3("Rho-east")
 
-static const uint32_t    RC[MAXROUNDS] __attribute__((unused)) = {
+#if defined(__GNUC__) || defined(__clang__)
+    #define UNUSED __attribute__((unused))
+#else
+    #define UNUSED
+#endif
+
+static const uint32_t    RC[MAXROUNDS] UNUSED = {
     _rc12,
     _rc11,
     _rc10,


### PR DESCRIPTION
Explodes violently in MSVC due to regression introduced by non-standard \_\_attribute\_\_ in https://github.com/XKCP/XKCP/pull/162.