### PR TITLE
Fix unaligned load in KeccakP1600times4_AVX2_AddBytes

### DIFF
--- a/lib/low/KeccakP-1600-times4/AVX2/KeccakP-1600-times4-AVX2.c
+++ b/lib/low/KeccakP-1600-times4/AVX2/KeccakP-1600-times4-AVX2.c
@@ -104,7 +104,8 @@ void KeccakP1600times4_AVX2_AddBytes(KeccakP1600times4_SIMD256_states *states, u
     }
 
     while(sizeLeft >= SnP_laneLengthInBytes) {
-        uint64_t lane = *((const uint64_t*)curData);
+        uint64_t lane = 0;
+        memcpy(&lane, curData, SnP_laneLengthInBytes);
         statesAsLanes[laneIndex(instanceIndex, lanePosition)] ^= lane;
         sizeLeft -= SnP_laneLengthInBytes;
         lanePosition++;


### PR DESCRIPTION
This fixes one issue that I found in #171. There still seem to be more alignment issues in other parts of the code (see #171).